### PR TITLE
chore(flake/nur): `1cb26887` -> `d3b995c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727372286,
-        "narHash": "sha256-FzxzdW3qyQK949FM1HBYwPHck1pthknphECkxHBqbEo=",
+        "lastModified": 1727379986,
+        "narHash": "sha256-XJVV4dZJaHoJPdydjcHJ/+l4mj1zpOmDBcwM53+JCIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cb268872ecbbb8bcdd76937b1f7536de880811b",
+        "rev": "d3b995c4e8d6b52f472c545f387f99ca47f8517a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d3b995c4`](https://github.com/nix-community/NUR/commit/d3b995c4e8d6b52f472c545f387f99ca47f8517a) | `` automatic update `` |