### PR TITLE
chore(flake/hyprland): `77f2a013` -> `b2143a98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,6 +223,7 @@
       "inputs": {
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
+        "hyprland-protocols": "hyprland-protocols",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -231,11 +232,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1727374627,
-        "narHash": "sha256-YHxA4vXv59gY+cQ2vlzJupMNl3OGOOBCnMN1Zv8epVM=",
+        "lastModified": 1727384872,
+        "narHash": "sha256-T+L5y5GeeZueI8Awv6TESoKVkDICmuD19U09QmuhZhk=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "77f2a01304f33a2dc7c9002ca9fb20a7653e6ae1",
+        "rev": "b2143a98e2719012f8c36211a066f8ebccc950b8",
         "type": "github"
       },
       "original": {
@@ -245,6 +246,31 @@
       }
     },
     "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721326555,
+        "narHash": "sha256-zCu4R0CSHEactW9JqYki26gy8h9f6rHmSwj4XJmlHgg=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "5a11232266bf1a1f5952d5b179c3f4b2facaaa84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols_2": {
       "inputs": {
         "nixpkgs": [
           "hyprland",
@@ -571,7 +597,7 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols",
+        "hyprland-protocols": "hyprland-protocols_2",
         "hyprlang": [
           "hyprland",
           "hyprlang"


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`b2143a98`](https://github.com/hyprwm/Hyprland/commit/b2143a98e2719012f8c36211a066f8ebccc950b8) | `` CI/Nix: no longer build with submodules ``                               |
| [`f75f8efb`](https://github.com/hyprwm/Hyprland/commit/f75f8efb1be227e586cc0ba2ce6153ce56e04314) | `` Meson: add tracy dependency ``                                           |
| [`be96787e`](https://github.com/hyprwm/Hyprland/commit/be96787ed086f751455cf713739296b5c6e3a235) | `` CMake: use udis86 from pkg-config, fallback to subproject ``             |
| [`89d945aa`](https://github.com/hyprwm/Hyprland/commit/89d945aabe632387f113ac500bfee573d51cc4f7) | `` CMake: use hyprland-protocols from pkg-config, fallback to subproject `` |
| [`27211c71`](https://github.com/hyprwm/Hyprland/commit/27211c71e92e1bacf111d8a815e958f80969ce6e) | `` Meson: try to find udis86 through pkgconfig, fallback to subproject ``   |
| [`14942bca`](https://github.com/hyprwm/Hyprland/commit/14942bca60cc7d85e8238a151bd444112601ebe6) | `` Nix: re-add hyprland-protocols ``                                        |