### PR TITLE
chore(flake/nur): `10b5e865` -> `118b6b0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,10 @@
   "nodes": {
     "aquamarine": {
       "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprutils": ["hyprland", "hyprutils"],
+        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1726665257,
@@ -51,9 +39,7 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
@@ -172,9 +158,7 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1727381010,
@@ -192,18 +176,9 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprlang": ["hyprland", "hyprlang"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1722623071,
@@ -247,14 +222,8 @@
     },
     "hyprland-protocols": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1721326555,
@@ -272,16 +241,8 @@
     },
     "hyprland-protocols_2": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "xdph",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "xdph",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "xdph", "nixpkgs"],
+        "systems": ["hyprland", "xdph", "systems"]
       },
       "locked": {
         "lastModified": 1721326555,
@@ -299,18 +260,9 @@
     },
     "hyprlang": {
       "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprutils": ["hyprland", "hyprutils"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1725997860,
@@ -328,14 +280,8 @@
     },
     "hyprutils": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727219120,
@@ -353,14 +299,8 @@
     },
     "hyprwayland-scanner": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1726840673,
@@ -378,9 +318,7 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1726975622,
@@ -532,9 +470,7 @@
     "spicetify-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1727410670,
@@ -598,26 +534,11 @@
     "xdph": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols_2",
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprlang": ["hyprland", "hyprlang"],
+        "hyprutils": ["hyprland", "hyprutils"],
+        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727109343,

--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727383411,
-        "narHash": "sha256-UCofyT4HT7T1Fz93NCe2l3qLmHdmBsjhvjTeDPKbEY8=",
+        "lastModified": 1727436058,
+        "narHash": "sha256-1lr9xYxyuYWbEJSWTXtYIDFhzrVtdHsC6a9uN76nkpY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "10b5e865f7e2ad5fd8b390e5940f5c3774cfb694",
+        "rev": "118b6b0bb575efc1b0632e91e064c4930881bdf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                 |
| -------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`118b6b0b`](https://github.com/nix-community/NUR/commit/118b6b0bb575efc1b0632e91e064c4930881bdf6) | `` automatic update ``                  |
| [`bce60b3f`](https://github.com/nix-community/NUR/commit/bce60b3fbdfaf80f255a26cf2597ef76586b2cc3) | `` automatic update ``                  |
| [`a1e60460`](https://github.com/nix-community/NUR/commit/a1e6046036bef187dbe56bbdd25b4a9fca286923) | `` automatic update ``                  |
| [`a3494e9d`](https://github.com/nix-community/NUR/commit/a3494e9def7d07a1d97fb4acfa13bff7da65fd2e) | `` automatic update ``                  |
| [`1d69d8ef`](https://github.com/nix-community/NUR/commit/1d69d8efe061f78d0be583d1e7d7b9ae6b294762) | `` Remove exploitoverload repository `` |
| [`a79f96c4`](https://github.com/nix-community/NUR/commit/a79f96c4ec0822ecd3c91467bbe98bae0ccbffb0) | `` automatic update ``                  |
| [`e45d72b7`](https://github.com/nix-community/NUR/commit/e45d72b7a9aa413f2914a4198d25b32efef4f3cd) | `` automatic update ``                  |
| [`77418664`](https://github.com/nix-community/NUR/commit/7741866413a6f232cc763b740d7e02a9cafa9b54) | `` automatic update ``                  |
| [`29e6d9d9`](https://github.com/nix-community/NUR/commit/29e6d9d93fca1f1093a432c21104c72a8d044fee) | `` automatic update ``                  |
| [`c5a2f27d`](https://github.com/nix-community/NUR/commit/c5a2f27d5449b727acd17cc28c47887bb01e0d75) | `` automatic update ``                  |
| [`d1aed1f0`](https://github.com/nix-community/NUR/commit/d1aed1f0c187add1bd925bf54e5dd8c6d6ff1f7c) | `` automatic update ``                  |
| [`ce6a8a89`](https://github.com/nix-community/NUR/commit/ce6a8a89b5cfcd9432ca52341d227980007b3e7a) | `` automatic update ``                  |
| [`4af98371`](https://github.com/nix-community/NUR/commit/4af983718431308f7b66f4462f850415550cdf63) | `` automatic update ``                  |
| [`b72e856d`](https://github.com/nix-community/NUR/commit/b72e856db30b30eb051b8e64072643d91cf07089) | `` automatic update ``                  |
| [`a9adaa2e`](https://github.com/nix-community/NUR/commit/a9adaa2e3167fb9e448657e82934b801d86f1a8e) | `` automatic update ``                  |
| [`ae2bbc79`](https://github.com/nix-community/NUR/commit/ae2bbc79a7a1152e5e6891e9aa0bb6bc0cd02eaf) | `` automatic update ``                  |
| [`fddab4d5`](https://github.com/nix-community/NUR/commit/fddab4d5f75b54ba75951796b6429a1e5e033b99) | `` automatic update ``                  |
| [`c73cc9b1`](https://github.com/nix-community/NUR/commit/c73cc9b1ae96c780aea40b277077331a40a7ba5c) | `` automatic update ``                  |
| [`5b0033f5`](https://github.com/nix-community/NUR/commit/5b0033f5873591f9b0355da2e4c9dd743cfc3668) | `` automatic update ``                  |
| [`8b9e5a32`](https://github.com/nix-community/NUR/commit/8b9e5a323cff048040ce2be328efbe89ec602097) | `` automatic update ``                  |
| [`8245c644`](https://github.com/nix-community/NUR/commit/8245c64422eca99aac81c537bb5e6c45345b9312) | `` automatic update ``                  |
| [`da3e0092`](https://github.com/nix-community/NUR/commit/da3e009286df98fe6449a60f88034c1a538014e7) | `` automatic update ``                  |
| [`a92d64c3`](https://github.com/nix-community/NUR/commit/a92d64c3084268ad618ef29905465ad0a874018f) | `` automatic update ``                  |