### PR TITLE
chore(flake/nur): `72fcc12f` -> `373fa5cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727468995,
-        "narHash": "sha256-TXMkCoFOpINEH8EP93ovsOdwDunCwK5eLe+ORUqe3DQ=",
+        "lastModified": 1727473540,
+        "narHash": "sha256-v/F4sVIWTgRq2BT3O9IK0wIcHXUglUDjrn+gTW9qGvI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "72fcc12fb07436d526b3158c7716f1333679b8c8",
+        "rev": "373fa5cb9b1392eaf1058cb0cb2b48391e03a9da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`373fa5cb`](https://github.com/nix-community/NUR/commit/373fa5cb9b1392eaf1058cb0cb2b48391e03a9da) | `` automatic update `` |
| [`7b186f5f`](https://github.com/nix-community/NUR/commit/7b186f5f9000c180cb8b2bbcf1713370e99635a2) | `` automatic update `` |