### PR TITLE
chore(flake/nixpkgs-ruby): `c7a557d4` -> `f13d235d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1727242955,
-        "narHash": "sha256-WAZ83atGrMbVywXhVcuTe7Evj1OeFN2TGAVpYlSz0BI=",
+        "lastModified": 1727485288,
+        "narHash": "sha256-uAKQuNXmviacoZgy357Y5ajuUBeaQfa2YlzrhHWH1lo=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "c7a557d4bc508e3a94849d3ad5006937d6c6ad70",
+        "rev": "f13d235da6084b5e872e81678bcf17c06e7e7a2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                        | Message                                              |
| ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`eb1bd106`](https://github.com/bobvanderlinden/nixpkgs-ruby/commit/eb1bd106cf97ebbb16b6fb2dbb83143564996479) | `` Update cachix/install-nix-action action to v29 `` |