### PR TITLE
chore(flake/hyprland): `58669fef` -> `2cf6e786`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1727451329,
-        "narHash": "sha256-dKV8GjIudv+HEW0fT68gyqvU6ZkG6QJAeTsqgPELpiw=",
+        "lastModified": 1727484580,
+        "narHash": "sha256-r8YskbfN2eXFlTG4bq5Wl9KTJR1PYdTg6YTHm+E/zEc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "58669fef77ac17ea205ce3570f48e17de736111f",
+        "rev": "2cf6e7862a844ad96aa060d63f6774df7e2234a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`2cf6e786`](https://github.com/hyprwm/Hyprland/commit/2cf6e7862a844ad96aa060d63f6774df7e2234a6) | `` dwindle: add config option `split_bias` (#7920) `` |