### PR TITLE
chore(flake/nur): `70927943` -> `69d2128b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727506142,
-        "narHash": "sha256-NzcMxwZSe+D7TJAiLWbp2peBkkXOAOQzcabJqLFFLOQ=",
+        "lastModified": 1727517643,
+        "narHash": "sha256-j3+7WR8swHrLAy2EzRsRG6J6t64y3S31NXvmwtZkuho=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "70927943520aee93363191b0ecc7d163bc05aa2a",
+        "rev": "69d2128b623b8d0a2542dcc0cb1fe0df8ff71c2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`69d2128b`](https://github.com/nix-community/NUR/commit/69d2128b623b8d0a2542dcc0cb1fe0df8ff71c2e) | `` automatic update `` |
| [`5c824607`](https://github.com/nix-community/NUR/commit/5c824607149f5c40a04f986d501c37d9c3128759) | `` automatic update `` |