### PR TITLE
chore(flake/nur): `08546da0` -> `d48ce424`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727520353,
-        "narHash": "sha256-55giv557fcrpCMMiqguMNQudETujcNm5QFu7gDeMduc=",
+        "lastModified": 1727523012,
+        "narHash": "sha256-8TK7kzUmmP5KzUDMgH7rg6PW8ITDn1xbu+fpNiQG1v4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "08546da084eec64003fb90a2902155ff2a9271af",
+        "rev": "d48ce4241d67a59751722b28d1b873be02d7903c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d48ce424`](https://github.com/nix-community/NUR/commit/d48ce4241d67a59751722b28d1b873be02d7903c) | `` automatic update `` |