### PR TITLE
chore(flake/nur): `d48ce424` -> `d148b56d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727523012,
-        "narHash": "sha256-8TK7kzUmmP5KzUDMgH7rg6PW8ITDn1xbu+fpNiQG1v4=",
+        "lastModified": 1727528107,
+        "narHash": "sha256-lITknUGWTaXxIkNeijopSsl26Q5xhOKmtH5f9y3OX5A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d48ce4241d67a59751722b28d1b873be02d7903c",
+        "rev": "d148b56d5f3f8774c8dfabc269bbabd65afde015",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d148b56d`](https://github.com/nix-community/NUR/commit/d148b56d5f3f8774c8dfabc269bbabd65afde015) | `` automatic update `` |