### PR TITLE
chore(flake/nur): `96aee93e` -> `c24d46ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727555235,
-        "narHash": "sha256-CnBRFruyO8doi3IdHRUV5rP9XcScfVWTeuOAhCALces=",
+        "lastModified": 1727576171,
+        "narHash": "sha256-8RNCvCpKnfPBXIdxK7WoVMMEXZbbe3pq8zY+yKBGkK8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "96aee93e0e6daf3e0f649f2e3e9140c0934678f7",
+        "rev": "c24d46abffc82fd4c89dec3a2c5eea823175ba08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c24d46ab`](https://github.com/nix-community/NUR/commit/c24d46abffc82fd4c89dec3a2c5eea823175ba08) | `` automatic update `` |
| [`09e1e8d1`](https://github.com/nix-community/NUR/commit/09e1e8d1f0d17a6a7eeb441ae5d91264ee2a2e3e) | `` automatic update `` |
| [`742ea7b8`](https://github.com/nix-community/NUR/commit/742ea7b8a25da31bc42318bcc45fd03e9aed1034) | `` automatic update `` |