### PR TITLE
chore(flake/nix-index-database): `41c3f28c` -> `a2ab1588`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,11 +383,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727579807,
-        "narHash": "sha256-lqkGlF4RcEG2teFD4WscK6KuSLI69qhs6cyG/C0VNGs=",
+        "lastModified": 1727580512,
+        "narHash": "sha256-gEWoJ+027OwsNs6f1GkDPrCxBFr5Vky7vWKjHRJi60s=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "41c3f28cd02b19a4a728d97ac1827353b90e3e36",
+        "rev": "a2ab1588541ae442bd3a682f8f6bbcbca2672f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a2ab1588`](https://github.com/nix-community/nix-index-database/commit/a2ab1588541ae442bd3a682f8f6bbcbca2672f10) | `` update generated.nix to release 2024-09-29-031659 `` |