### PR TITLE
chore(flake/spicetify-nix): `65a95ae7` -> `cf348178`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727496988,
-        "narHash": "sha256-fi7G9bODA4iUN1g9psIE1U3h7xulNLtwAq0ziwLh0oM=",
+        "lastModified": 1727583380,
+        "narHash": "sha256-Wd73LwQvQufwlPWsCPTvc/hV7dYbQl6i9dS0e1hQTdA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "65a95ae7c145ed836ca7d4a1e6be5154125490cf",
+        "rev": "cf34817877db467a9c881ffa1de3d2822fdc137a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`cf348178`](https://github.com/Gerg-L/spicetify-nix/commit/cf34817877db467a9c881ffa1de3d2822fdc137a) | `` CI update 2024-09-29 `` |