### PR TITLE
chore(flake/nur): `d6c50bc0` -> `78703795`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727589136,
-        "narHash": "sha256-dEjJx3IWyJ/eholFAZl7weaJxQzCc089+JK7OflO2DY=",
+        "lastModified": 1727592347,
+        "narHash": "sha256-jFLfLl12KZEBZpRv5nx5b2UWhilNOtISNlDFsfvvN3g=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d6c50bc086a44dc5af3ab267b0af64203cba9eaa",
+        "rev": "787037957a959c391cede085702224cd5e366af1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`78703795`](https://github.com/nix-community/NUR/commit/787037957a959c391cede085702224cd5e366af1) | `` automatic update `` |
| [`61bca450`](https://github.com/nix-community/NUR/commit/61bca4508a3fc93822cf2007966a94a0174e1f22) | `` automatic update `` |