### PR TITLE
chore(flake/nur): `78703795` -> `6acf80f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727592347,
-        "narHash": "sha256-jFLfLl12KZEBZpRv5nx5b2UWhilNOtISNlDFsfvvN3g=",
+        "lastModified": 1727596560,
+        "narHash": "sha256-222fcWG6s13RXuAK711nbrHs6wOb3UORXJ/vt3rCM60=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "787037957a959c391cede085702224cd5e366af1",
+        "rev": "6acf80f88c3f8fbf4f95f5df7a936a488a7bca12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6acf80f8`](https://github.com/nix-community/NUR/commit/6acf80f88c3f8fbf4f95f5df7a936a488a7bca12) | `` automatic update `` |