### PR TITLE
chore(flake/nur): `ebcdd5af` -> `f3fd2cfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727600709,
-        "narHash": "sha256-RQbTtkoMS1dJ/VRYaoeV6qTxo9aSFeBaKSGPmCgBDBk=",
+        "lastModified": 1727604182,
+        "narHash": "sha256-jVtCN/X4+5JjsWvA5Fa36l19SQrGbx4iIjG78Q3xoY0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebcdd5afc9751dfcb371197e209af22febaf45b9",
+        "rev": "f3fd2cfb47f11b53c881db7b2edc86d8c9d55bb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3fd2cfb`](https://github.com/nix-community/NUR/commit/f3fd2cfb47f11b53c881db7b2edc86d8c9d55bb5) | `` automatic update `` |