### PR TITLE
chore(flake/nur): `f3fd2cfb` -> `3c37b6df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727604182,
-        "narHash": "sha256-jVtCN/X4+5JjsWvA5Fa36l19SQrGbx4iIjG78Q3xoY0=",
+        "lastModified": 1727605244,
+        "narHash": "sha256-ppcC/W/rKLQr1F2iA+7ClWhx6fhewh59em5qkXf3G70=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3fd2cfb47f11b53c881db7b2edc86d8c9d55bb5",
+        "rev": "3c37b6df4a773825187dd960dc0b330e387d34ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3c37b6df`](https://github.com/nix-community/NUR/commit/3c37b6df4a773825187dd960dc0b330e387d34ce) | `` automatic update `` |