### PR TITLE
chore(flake/nur): `3c37b6df` -> `4da20986`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727605244,
-        "narHash": "sha256-ppcC/W/rKLQr1F2iA+7ClWhx6fhewh59em5qkXf3G70=",
+        "lastModified": 1727653499,
+        "narHash": "sha256-sw144okxAM3L5Z1Gl1mlh2c3vstiDSeC0MB32vHNMLk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "3c37b6df4a773825187dd960dc0b330e387d34ce",
+        "rev": "4da209862c4aafa83e37b8a69808cde609db4f63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4da20986`](https://github.com/nix-community/NUR/commit/4da209862c4aafa83e37b8a69808cde609db4f63) | `` automatic update `` |
| [`e849a364`](https://github.com/nix-community/NUR/commit/e849a364c2890e3e75bda0575c4400b601373580) | `` automatic update `` |
| [`f7cae2fc`](https://github.com/nix-community/NUR/commit/f7cae2fc5cb4c89b3c22095c8a8f73f757949fc8) | `` automatic update `` |
| [`58fea91b`](https://github.com/nix-community/NUR/commit/58fea91b49162a0a7e893e3acedc8f97bbb18aa9) | `` automatic update `` |
| [`1d88c938`](https://github.com/nix-community/NUR/commit/1d88c938b14e8c269d1d7b0ce389f194aef8679d) | `` automatic update `` |
| [`8ad93a63`](https://github.com/nix-community/NUR/commit/8ad93a63359caf2ed00d647264a59ca030691c71) | `` automatic update `` |
| [`5d4c40ea`](https://github.com/nix-community/NUR/commit/5d4c40ea4908dab154f80a89f82dc2f139ac4619) | `` automatic update `` |
| [`a057d959`](https://github.com/nix-community/NUR/commit/a057d9599f205958446629377ba0141f43bcf6eb) | `` automatic update `` |