### PR TITLE
chore(flake/spicetify-nix): `cf348178` -> `ec53a684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727583380,
-        "narHash": "sha256-Wd73LwQvQufwlPWsCPTvc/hV7dYbQl6i9dS0e1hQTdA=",
+        "lastModified": 1727669861,
+        "narHash": "sha256-Qb9DGXner4NnvSfO6IdvqoNgg8jUkIz7i8l+PSDviDk=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "cf34817877db467a9c881ffa1de3d2822fdc137a",
+        "rev": "ec53a68450d888d245dbf0d4b0f9365217d0ed5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`ec53a684`](https://github.com/Gerg-L/spicetify-nix/commit/ec53a68450d888d245dbf0d4b0f9365217d0ed5d) | `` CI update 2024-09-30 ``               |
| [`d0a8d745`](https://github.com/Gerg-L/spicetify-nix/commit/d0a8d7455133ec886c4723e5593a314625aaedaf) | `` add TODO.md ``                        |
| [`77a53c2f`](https://github.com/Gerg-L/spicetify-nix/commit/77a53c2fd59f829ace666aa371ec7004c1db5b5f) | `` change to more traditional builder `` |
| [`5a6eb6d0`](https://github.com/Gerg-L/spicetify-nix/commit/5a6eb6d07dd6599c2721e705bfab300f0b33b2f7) | `` set sidebarConfig to false always ``  |