### PR TITLE
chore(flake/nur): `4da20986` -> `58b501ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,10 @@
   "nodes": {
     "aquamarine": {
       "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprutils": ["hyprland", "hyprutils"],
+        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727261104,
@@ -51,9 +39,7 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
@@ -172,9 +158,7 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1727383923,
@@ -192,18 +176,9 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprlang": ["hyprland", "hyprlang"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727532803,
@@ -247,14 +222,8 @@
     },
     "hyprland-protocols": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727451107,
@@ -272,16 +241,8 @@
     },
     "hyprland-protocols_2": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "xdph",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "xdph",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "xdph", "nixpkgs"],
+        "systems": ["hyprland", "xdph", "systems"]
       },
       "locked": {
         "lastModified": 1721326555,
@@ -299,18 +260,9 @@
     },
     "hyprlang": {
       "inputs": {
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprutils": ["hyprland", "hyprutils"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1725997860,
@@ -328,14 +280,8 @@
     },
     "hyprutils": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727300645,
@@ -353,14 +299,8 @@
     },
     "hyprwayland-scanner": {
       "inputs": {
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1726874836,
@@ -378,9 +318,7 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1727658919,
@@ -532,9 +470,7 @@
     "spicetify-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
         "lastModified": 1727669861,
@@ -598,26 +534,11 @@
     "xdph": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols_2",
-        "hyprlang": [
-          "hyprland",
-          "hyprlang"
-        ],
-        "hyprutils": [
-          "hyprland",
-          "hyprutils"
-        ],
-        "hyprwayland-scanner": [
-          "hyprland",
-          "hyprwayland-scanner"
-        ],
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
+        "hyprlang": ["hyprland", "hyprlang"],
+        "hyprutils": ["hyprland", "hyprutils"],
+        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
+        "nixpkgs": ["hyprland", "nixpkgs"],
+        "systems": ["hyprland", "systems"]
       },
       "locked": {
         "lastModified": 1727524473,

--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727653499,
-        "narHash": "sha256-sw144okxAM3L5Z1Gl1mlh2c3vstiDSeC0MB32vHNMLk=",
+        "lastModified": 1727696691,
+        "narHash": "sha256-JVxM3hIXrIldCM1ZP7u7Z9ueGhnkFDKqU1+7gEzhaM0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4da209862c4aafa83e37b8a69808cde609db4f63",
+        "rev": "58b501eaed427de88e222820dd6bd225a7d95cd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                             |
| -------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`58b501ea`](https://github.com/nix-community/NUR/commit/58b501eaed427de88e222820dd6bd225a7d95cd7) | `` automatic update ``                              |
| [`c33dfeca`](https://github.com/nix-community/NUR/commit/c33dfeca43d1d61b478c6efacc59848b7367c5a1) | `` automatic update ``                              |
| [`3ed4a3f3`](https://github.com/nix-community/NUR/commit/3ed4a3f36e538bf16a1034c6e85f66d582b0dc92) | `` automatic update ``                              |
| [`13d4cb90`](https://github.com/nix-community/NUR/commit/13d4cb90be03e225cc11a96d019ec886c3c30296) | `` automatic update ``                              |
| [`8c9dbb18`](https://github.com/nix-community/NUR/commit/8c9dbb18aa6b84afdb4ff49e849e486dcd8f2175) | `` automatic update ``                              |
| [`5dd12262`](https://github.com/nix-community/NUR/commit/5dd1226203f930730ea4b432b2ce67e91462e235) | `` automatic update ``                              |
| [`ccf24b46`](https://github.com/nix-community/NUR/commit/ccf24b461b09725abd35f08830860625842daa8d) | `` automatic update ``                              |
| [`05951fb7`](https://github.com/nix-community/NUR/commit/05951fb772a6c4f0f6324a06d7f77891aa605d19) | `` Bump cachix/install-nix-action from V28 to 29 `` |
| [`0ed01312`](https://github.com/nix-community/NUR/commit/0ed0131228e7746e6ed8b067179f520c53f8643d) | `` automatic update ``                              |
| [`de0f11a2`](https://github.com/nix-community/NUR/commit/de0f11a21417c24ae4e059d1f8b694b09861b478) | `` automatic update ``                              |
| [`35f3dd58`](https://github.com/nix-community/NUR/commit/35f3dd58182e9e200b86312e4e6b65bfb06fe0d0) | `` automatic update ``                              |
| [`8cb5f411`](https://github.com/nix-community/NUR/commit/8cb5f411b9cc8d81811e0db837c9fee0673bb2a6) | `` automatic update ``                              |
| [`80f3e6b8`](https://github.com/nix-community/NUR/commit/80f3e6b8f510f79e88348df3ac24976520ee1bf0) | `` automatic update ``                              |
| [`0922b5d0`](https://github.com/nix-community/NUR/commit/0922b5d02c48f935707a54dbeea0905bb44fdff5) | `` automatic update ``                              |
| [`d0662614`](https://github.com/nix-community/NUR/commit/d06626145a8e70a22fa0bc10e7d4c07815b69b85) | `` automatic update ``                              |
| [`06cebdac`](https://github.com/nix-community/NUR/commit/06cebdace980f4c7b13be212a5c0115855fe976e) | `` automatic update ``                              |