### PR TITLE
chore(flake/nix-vscode-extensions): `2f5cbb7a` -> `6b2d41c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727589556,
-        "narHash": "sha256-iSsHGIOJ2sMoKpEOncVy/ippZmVqcQN5rMhxEh8OZU4=",
+        "lastModified": 1727660984,
+        "narHash": "sha256-jgusy1DsdNX5KRZOQ/DonKoMshcDMZ17dAc0eVlNTS8=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "2f5cbb7a6e05e1d5167e869ba3e7685115da12c6",
+        "rev": "6b2d41c8e20f8eb9f969ec4bd851b036ae688e14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message      |
| -------------------------------------------------------------------------------------------------------------------- | ------------ |
| [`6b2d41c8`](https://github.com/nix-community/nix-vscode-extensions/commit/6b2d41c8e20f8eb9f969ec4bd851b036ae688e14) | `` action `` |