### PR TITLE
chore(flake/nix-index-database): `a2ab1588` -> `f9fdf828`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -383,11 +383,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727580512,
-        "narHash": "sha256-gEWoJ+027OwsNs6f1GkDPrCxBFr5Vky7vWKjHRJi60s=",
+        "lastModified": 1727658919,
+        "narHash": "sha256-YAePt2GldkkRJ08LvZNHcuS6shIVStj+K+1DZN3gbnM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a2ab1588541ae442bd3a682f8f6bbcbca2672f10",
+        "rev": "f9fdf8285690a351e8998f1e703ebdf9cdf51dee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                          |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f9fdf828`](https://github.com/nix-community/nix-index-database/commit/f9fdf8285690a351e8998f1e703ebdf9cdf51dee) | `` build(deps): bump cachix/install-nix-action from V28 to 29 `` |