### PR TITLE
chore(flake/hyprland): `488efab6` -> `f6387536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1727654296,
-        "narHash": "sha256-UvF+UD22S2Y9o7m/lgO2fhC/ZUgVyectQ2w/3e/pR4U=",
+        "lastModified": 1727679999,
+        "narHash": "sha256-PwfsSwQ5XOKnoNWacT/e6fSgffnv66BKU1HsgAjazeQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "488efab63654a643d76df4997cd932d6fddd8faf",
+        "rev": "f6387536f62454f82039b42f641cd8c44153ad47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                       |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`f6387536`](https://github.com/hyprwm/Hyprland/commit/f6387536f62454f82039b42f641cd8c44153ad47) | `` protocol: fix missing include ``           |
| [`968f6a60`](https://github.com/hyprwm/Hyprland/commit/968f6a6013409a6e6eab1545b28cd5e0cc49ce87) | `` meson: fix arch build with new protocol `` |