### PR TITLE
chore(flake/nixpkgs): `1925c603` -> `06cf0e1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,22 @@
   "nodes": {
     "aquamarine": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1727261104,
@@ -39,7 +51,9 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
@@ -158,7 +172,9 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1727383923,
@@ -176,9 +192,18 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": ["hyprland", "hyprlang"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1727532803,
@@ -222,8 +247,14 @@
     },
     "hyprland-protocols": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1727451107,
@@ -241,8 +272,16 @@
     },
     "hyprland-protocols_2": {
       "inputs": {
-        "nixpkgs": ["hyprland", "xdph", "nixpkgs"],
-        "systems": ["hyprland", "xdph", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "xdph",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "xdph",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1721326555,
@@ -260,9 +299,18 @@
     },
     "hyprlang": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1725997860,
@@ -280,8 +328,14 @@
     },
     "hyprutils": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1727300645,
@@ -299,8 +353,14 @@
     },
     "hyprwayland-scanner": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1726874836,
@@ -318,7 +378,9 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1727658919,
@@ -408,11 +470,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {
@@ -470,7 +532,9 @@
     "spicetify-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1727669861,
@@ -534,11 +598,26 @@
     "xdph": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols_2",
-        "hyprlang": ["hyprland", "hyprlang"],
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1727524473,


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`af61785b`](https://github.com/NixOS/nixpkgs/commit/af61785ba3d73e6c2e20baea4f702ee334f2722a) | `` mistral-rs: 0.3.0 -> 0.3.1 ``                                                  |
| [`d7b94e35`](https://github.com/NixOS/nixpkgs/commit/d7b94e35200c1e77e1777ac58eb89250d0244b29) | `` vimPlugins.neorg: add test ``                                                  |
| [`36504618`](https://github.com/NixOS/nixpkgs/commit/365046188fc7ae2decc0bee0d65eeebea98e086d) | `` luaPackages.neorg: remove forgotten debug ``                                   |
| [`43bbc78d`](https://github.com/NixOS/nixpkgs/commit/43bbc78db704e059ceb533a651cf29300af180f0) | `` signal-desktop: 7.25.0 -> 7.26.0 ``                                            |
| [`2d70148c`](https://github.com/NixOS/nixpkgs/commit/2d70148c4d3ed710a0f1c12268aa391de92fbdb4) | `` vimPlugins.alpha-nvim: remove nvim-web-devicons dependency ``                  |
| [`dc1f2229`](https://github.com/NixOS/nixpkgs/commit/dc1f2229e0da4284c984c3ca91a7301b2c52f2dc) | `` vimPlugins.barbecue-nvim: remove nvim-web-devicons dependency ``               |
| [`fdb32075`](https://github.com/NixOS/nixpkgs/commit/fdb32075d27221e68a2714df2759278b35165375) | `` vimPlugins.markview-nvim: remove nvim-web-devicons dependency ``               |
| [`a95f58cc`](https://github.com/NixOS/nixpkgs/commit/a95f58cca4fa5d4ef2032d16e65f1be8ed7dfbe3) | `` llvmPackages_19: 19.1.0-rc3 -> 19.1.0 ``                                       |
| [`d6cae734`](https://github.com/NixOS/nixpkgs/commit/d6cae7344b6b8fc2c9d7b75ee9e18092ce1c10fc) | `` bartender: add DimitarNestorov to maintainers ``                               |
| [`ecfa8391`](https://github.com/NixOS/nixpkgs/commit/ecfa8391c5bf07accd471cec4450e33c05823a41) | `` bitrise: 2.20.1 -> 2.21.0 ``                                                   |
| [`5fcc1337`](https://github.com/NixOS/nixpkgs/commit/5fcc1337d2cac43a8ce8e7089256ca51676e7ae0) | `` nixos/waybar: enable systemdSupport for package ``                             |
| [`d68f1d23`](https://github.com/NixOS/nixpkgs/commit/d68f1d2354eb9a9575d421681b773bb7f487c088) | `` waybar: add systemdSupport input ``                                            |
| [`7ab8a078`](https://github.com/NixOS/nixpkgs/commit/7ab8a07891c30f64f51ba68860cc65e157ea45cf) | `` python312Packages.teslajsonpy: 3.12.0 -> 3.12.1 ``                             |
| [`6cb3b5f8`](https://github.com/NixOS/nixpkgs/commit/6cb3b5f8f9075d991451f5624d46849125845570) | `` python312Packages.pytouchlinesl: 0.1.5 -> 0.1.7 ``                             |
| [`2d302815`](https://github.com/NixOS/nixpkgs/commit/2d302815d20b6fe60f9dcd9b5a31388fe4cab3e9) | `` python312Packages.pysqueezebox: 0.9.2 -> 0.9.3 ``                              |
| [`8d82f45b`](https://github.com/NixOS/nixpkgs/commit/8d82f45b95ffd554d934f4f0111b4b11c1734416) | `` python312Packages.tencentcloud-sdk-python: 3.0.1241 -> 3.0.1242 ``             |
| [`58e889ea`](https://github.com/NixOS/nixpkgs/commit/58e889ea7e2b63383f500542d0124b3fe37d1174) | `` python312Packages.pyexploitdb: 0.2.36 -> 0.2.37 ``                             |
| [`3b335f27`](https://github.com/NixOS/nixpkgs/commit/3b335f27a54a78fe7de9b226ad1e55747227c7f1) | `` python312Packages.hishel: 0.0.31 -> 0.0.32 ``                                  |
| [`4785cf24`](https://github.com/NixOS/nixpkgs/commit/4785cf241dc8409a501eaadd02f9f0224046a34e) | `` python312Packages.aioopenexchangerates: 0.6.3 -> 0.6.5 ``                      |
| [`f3e705c7`](https://github.com/NixOS/nixpkgs/commit/f3e705c70eb6a3af3c78c29c513dcad7813e9572) | `` ldeep: 1.0.66 -> 1.0.67 ``                                                     |
| [`d3e0a89c`](https://github.com/NixOS/nixpkgs/commit/d3e0a89ca62863b7294ce1fda6eda468bd9eaa90) | `` nixos/logrotate: relax hardening ``                                            |
| [`25d86507`](https://github.com/NixOS/nixpkgs/commit/25d86507bb5cb079913c8d9446a639c0c1600712) | `` mtools: 4.0.44 -> 4.0.45 ``                                                    |
| [`0896eb4c`](https://github.com/NixOS/nixpkgs/commit/0896eb4cbbc300df2ebdebb13adc381191ba0499) | `` cryptomator: 1.13.0 -> 1.14.1 ``                                               |
| [`d2853aed`](https://github.com/NixOS/nixpkgs/commit/d2853aed855ff4ff39b2771c7f95fd033a9dae5a) | `` ryujinx: 1.1.1398 -> 1.1.1401 ``                                               |
| [`7c753112`](https://github.com/NixOS/nixpkgs/commit/7c75311202685e2a550b742b5eaf3ddfc45eaeb7) | `` rqlite: 8.30.3 -> 8.31.0 ``                                                    |
| [`2f204572`](https://github.com/NixOS/nixpkgs/commit/2f204572c6bdb1272b6ecd9b9de8c5b1551dd292) | `` nixos-rebuild: remove accidentally lost check ``                               |
| [`6646215c`](https://github.com/NixOS/nixpkgs/commit/6646215ce88074932bdd5951cb92b5157761c81f) | `` haproxy: 3.0.4 -> 3.0.5 ``                                                     |
| [`497561b9`](https://github.com/NixOS/nixpkgs/commit/497561b99a0a3dfbb10757615996f4c54c888c66) | `` firefoxpwa: 2.12.4 -> 2.12.5 ``                                                |
| [`14e14fa5`](https://github.com/NixOS/nixpkgs/commit/14e14fa5479ceadc031718d6527185eee5d5b857) | `` ast-grep: 0.27.1 -> 0.27.3 ``                                                  |
| [`620fee74`](https://github.com/NixOS/nixpkgs/commit/620fee7437aa9c17bb0ab8348ec47470bf9be715) | `` phpExtensions: clean up old libxml compat patches ``                           |
| [`1feabef0`](https://github.com/NixOS/nixpkgs/commit/1feabef0caa27b91e894abeafe406324d3181a86) | `` srgn: 0.13.1 -> 0.13.2 ``                                                      |
| [`ffec0c44`](https://github.com/NixOS/nixpkgs/commit/ffec0c4485ac46d0d200311567ef41d910b78262) | `` application-title-bar: 0.7.2 -> 0.7.3 ``                                       |
| [`ce706866`](https://github.com/NixOS/nixpkgs/commit/ce7068660a63abca25f9284d39d95bdddce7175b) | `` nixos/xdg/icons: add `fallbackThemes` option ``                                |
| [`bd1ec990`](https://github.com/NixOS/nixpkgs/commit/bd1ec9901bd8dd2647a7ebb476fd513bb92d05d2) | `` esptool: 4.8.0 -> 4.8.1 ``                                                     |
| [`170923d1`](https://github.com/NixOS/nixpkgs/commit/170923d16b7d8883592336ff4d23b22db6a6a724) | `` firefly-iii: 6.1.20 -> 6.1.21 ``                                               |
| [`b53d059d`](https://github.com/NixOS/nixpkgs/commit/b53d059d5edd09fdc8121f23020184e177bb4408) | `` supermariowar: 2023-unstable-2024-09-17 -> 2023-unstable-2024-09-21 ``         |
| [`ea97c3fe`](https://github.com/NixOS/nixpkgs/commit/ea97c3fed13d851af8e4836f78ee8f6c1efc9476) | `` python312Packages.hyrule: 0.6.0 -> 0.7.0 ``                                    |
| [`1351ea87`](https://github.com/NixOS/nixpkgs/commit/1351ea8708b7416681c2e7e66a0928e2b6d7c8d9) | `` python312Packages.python-utils: switch to pypa builder ``                      |
| [`0137e787`](https://github.com/NixOS/nixpkgs/commit/0137e787c8138a2d07053f800d835de2808d4750) | `` python312Packages.pivy: enable pythonImportsCheck ``                           |
| [`a8d08f26`](https://github.com/NixOS/nixpkgs/commit/a8d08f26502b9c4e8ae2f819ba7564ee6e74a13a) | `` python312Packages.pivy: switch to pypa builder ``                              |
| [`d1f806d5`](https://github.com/NixOS/nixpkgs/commit/d1f806d5d892cf54304993c67009fd1cb0ec475c) | `` quickwit: fix compilation with rust 1.80 ``                                    |
| [`8d31f5e0`](https://github.com/NixOS/nixpkgs/commit/8d31f5e0fe893ffc33570626f36956293757bb37) | `` python312Packages.psd-tools: refactor inputs ``                                |
| [`d8f146c8`](https://github.com/NixOS/nixpkgs/commit/d8f146c8180d88259b8b1642cdded34d452dbea5) | `` python312Packages.psd-tools: switch to pypa builder ``                         |
| [`4a9f452e`](https://github.com/NixOS/nixpkgs/commit/4a9f452e171c379c4225af6186d80574a1dba98a) | `` python312Packages.sasmodels: refactor inputs ``                                |
| [`7d1fd250`](https://github.com/NixOS/nixpkgs/commit/7d1fd25075c2095daebed0d566d3ea2298b3759e) | `` python312Packages.sasmodels: switch to pypa builder ``                         |
| [`ab7c2bf2`](https://github.com/NixOS/nixpkgs/commit/ab7c2bf24d01266908372382f72605f907fd1f49) | `` python312Packages.tlsh: refator meta ``                                        |
| [`88a8c2dc`](https://github.com/NixOS/nixpkgs/commit/88a8c2dcbdc4ff7e795723c9585751714cc67a84) | `` python312Packages.tlsh: enable pythonImportsCheck ``                           |
| [`cabaa399`](https://github.com/NixOS/nixpkgs/commit/cabaa399251c75b994277a54eb048c0f347699d7) | `` python312Packages.tlsh: switch to pypa builder ``                              |
| [`78275c27`](https://github.com/NixOS/nixpkgs/commit/78275c27a1a80a4111c1986eaa9eb75ed9f32408) | `` python312Packages.django-rosetta: switch to pypa builder ``                    |
| [`303c76e5`](https://github.com/NixOS/nixpkgs/commit/303c76e5cf4a78fa5a575aed37f3da3397bc2aab) | `` python312Packages.mkdocs-material: 9.5.35 -> 9.5.38 ``                         |
| [`a10c8553`](https://github.com/NixOS/nixpkgs/commit/a10c8553fc0daffdbd1f68ee2313e8a4b81e1d7f) | `` spaceship-prompt: 4.16.1 -> 4.16.2 ``                                          |
| [`1226f380`](https://github.com/NixOS/nixpkgs/commit/1226f380447f68c461a25008d8b14030f08f3af4) | `` pls: 0.0.1-beta.7 -> 0.0.1-beta.8 ``                                           |
| [`429fcf33`](https://github.com/NixOS/nixpkgs/commit/429fcf33315ce01d5f3737bab7e1bdbd57ffc9ee) | `` mdbook-alerts: 0.6.5 -> 0.6.6 ``                                               |
| [`4a1558c5`](https://github.com/NixOS/nixpkgs/commit/4a1558c5feaa3a3f558e8512590e68f1a9c87e17) | `` python3Packages.manga-ocr: 0.1.11 -> 0.1.12 ``                                 |
| [`3bd8b065`](https://github.com/NixOS/nixpkgs/commit/3bd8b06582ff0d9674eaf7f73739d846506df825) | `` troubadix: 24.9.2 -> 24.9.4 ``                                                 |
| [`a714fcd0`](https://github.com/NixOS/nixpkgs/commit/a714fcd0ea99d5f05ce41bac3e397914368ec0e9) | `` ssdfs-utils: 4.43 -> 4.45 ``                                                   |
| [`111d78b3`](https://github.com/NixOS/nixpkgs/commit/111d78b38ee8652ccce1a326bee5cce6db9b4ae0) | `` python312Packages.ihm: 1.4 -> 1.6 ``                                           |
| [`dd65d15c`](https://github.com/NixOS/nixpkgs/commit/dd65d15cc0f1d4471972f9c0c2693c1765f203a1) | `` picom: v12 -> v12.1 ``                                                         |
| [`c29ce19a`](https://github.com/NixOS/nixpkgs/commit/c29ce19aa1064d05488178177ba3b001eca6382d) | `` metacubexd: 1.149.0 -> 1.150.0 ``                                              |
| [`f11d291c`](https://github.com/NixOS/nixpkgs/commit/f11d291c2e437b8bedcd997f1dac17bcafbd1151) | `` pythonPackages.pyinstaller: fix darwin build ``                                |
| [`ab4dc6ca`](https://github.com/NixOS/nixpkgs/commit/ab4dc6ca78809a367aba6fb2813a15116560e2a9) | `` doc/javascript: fix example usage of yarn hooks ``                             |
| [`a394d78f`](https://github.com/NixOS/nixpkgs/commit/a394d78f618b740e11e0f61ceaafd814560a3a44) | `` immich-machine-learning: add passthru.tests ``                                 |
| [`1e5c3753`](https://github.com/NixOS/nixpkgs/commit/1e5c3753258332d249af0e350be09816b6264303) | `` immich-machine-learning: only add run time dependencies to PYTHONPATH ``       |
| [`d6e1e2c8`](https://github.com/NixOS/nixpkgs/commit/d6e1e2c8a2ec8f0500b33900f6f32eaf6d1fd5cd) | `` irust: 1.71.23 -> 1.71.24 ``                                                   |
| [`fb6389cb`](https://github.com/NixOS/nixpkgs/commit/fb6389cb8033025b6709fd77e9bb8d53441d1f0f) | `` python312Packages.python-opendata-transport: refactor ``                       |
| [`36e31275`](https://github.com/NixOS/nixpkgs/commit/36e31275ba89b2f49677cae7d24d8aa95ed39953) | `` python312Packages.python-opendata-transport: 0.4.0 -> 0.5.0 ``                 |
| [`184807a8`](https://github.com/NixOS/nixpkgs/commit/184807a8ba36c869e73b6a431cda5a86f3db4d8f) | `` navidrome: 0.53.2 -> 0.53.3 ``                                                 |
| [`61823954`](https://github.com/NixOS/nixpkgs/commit/618239546a838ad7fe26fc72920bb3da6ef2907c) | `` gnupg24: add myself as maintainer ``                                           |
| [`e2ba9edc`](https://github.com/NixOS/nixpkgs/commit/e2ba9edc297df26732330b7dfc26f5892b0b01ad) | `` act: 0.2.66 -> 0.2.67 (#343620) ``                                             |
| [`e95f5b75`](https://github.com/NixOS/nixpkgs/commit/e95f5b757ac7507a8d829db387dc023f6a572884) | `` python312Packages.kserve: add optional-dependencies ``                         |
| [`0471e7aa`](https://github.com/NixOS/nixpkgs/commit/0471e7aa5b8da32dcd69746e980e8e2f8f5befbf) | `` hurl: add versionCheckHook ``                                                  |
| [`34070318`](https://github.com/NixOS/nixpkgs/commit/3407031806b610f87d979d397ab0a38060e8a79e) | `` hurl: 4.3.0 -> 5.0.1 ``                                                        |
| [`174479d0`](https://github.com/NixOS/nixpkgs/commit/174479d0404df19ecc6cb8e9a06c9f4e41a30a27) | `` playwright-driver.browsers: expose raw fontconfig file ``                      |
| [`c461b76c`](https://github.com/NixOS/nixpkgs/commit/c461b76cebd36dd414e83c76b907a625b820ea8d) | `` python312Packages.camel-converter: fix description ``                          |
| [`b1ef053e`](https://github.com/NixOS/nixpkgs/commit/b1ef053efa89c18a42903a30bff4f92e40d68fe3) | `` python312Packages.camel-converter: 3.1.2 -> 4.0.0 ``                           |
| [`6512103d`](https://github.com/NixOS/nixpkgs/commit/6512103dfe744c6613aa9a6929835066fc5a137e) | `` nixos/monero: remove `with lib;` ``                                            |
| [`5e83503d`](https://github.com/NixOS/nixpkgs/commit/5e83503dc011d4460523dd6c35393beb03b91523) | `` python312Packages.vllm: mark as broken ``                                      |
| [`3925d753`](https://github.com/NixOS/nixpkgs/commit/3925d753c67c44d9432d968d6ca09f8133ff01c1) | `` homepage-dashboard: 0.9.9 -> 0.9.10 ``                                         |
| [`7249b5cc`](https://github.com/NixOS/nixpkgs/commit/7249b5cc222ad856d9335fc9ed1d2abfac19b7ad) | `` gotosocial: build with kvformat tag ``                                         |
| [`1dd26e8b`](https://github.com/NixOS/nixpkgs/commit/1dd26e8b3a70767016a65c3e13f2352a082fb4dd) | `` metasploit: 6.4.26 -> 6.4.28 ``                                                |
| [`57435d57`](https://github.com/NixOS/nixpkgs/commit/57435d57f61962102af8571eb78ba345d4dc8ec9) | `` eza: fix version in man page ``                                                |
| [`51d1a64a`](https://github.com/NixOS/nixpkgs/commit/51d1a64adba4fe23fe160527ff282f69d63f7053) | `` grype: 0.80.2 -> 0.81.0 ``                                                     |
| [`c816459d`](https://github.com/NixOS/nixpkgs/commit/c816459d32a6bd0dfaf32c79d352f30fad9e6963) | `` python312Packages.oci: 2.134.0 -> 2.135.0 ``                                   |
| [`05bd4e31`](https://github.com/NixOS/nixpkgs/commit/05bd4e31cc37d102ac7f95a529e19ea0989574ae) | `` werf: 2.10.6 -> 2.10.7 ``                                                      |
| [`aca27a5a`](https://github.com/NixOS/nixpkgs/commit/aca27a5a39b8a55a36ec061a3ed6cc1619cac7d7) | `` python312Packages.pytenable: 1.5.2 -> 1.5.3 ``                                 |
| [`1685e3c6`](https://github.com/NixOS/nixpkgs/commit/1685e3c661d8e53eb897b0c6318d28f89b9e1d6e) | `` python312Packages.pyotgw: 2.2.0 -> 2.2.1 ``                                    |
| [`5d0617ac`](https://github.com/NixOS/nixpkgs/commit/5d0617ac822c69fa4dbc7699b67885edc4f8e2bc) | `` hyprlandPlugins.hyprsplit: init at 0.43.0 ``                                   |
| [`89fca964`](https://github.com/NixOS/nixpkgs/commit/89fca964c0352691e9295a358cbc8dddb510654f) | `` python312Packages.icontract: 2.7.0 -> 2.7.1 ``                                 |
| [`0a7d6bb9`](https://github.com/NixOS/nixpkgs/commit/0a7d6bb9c38f4542de7c46cae4782bc45e7faeab) | `` libretro.gambatte: unstable-2024-09-06 -> unstable-2024-09-27 ``               |
| [`c4f77e0f`](https://github.com/NixOS/nixpkgs/commit/c4f77e0fc532377309afdac75e5eb9b5f2277510) | `` firefly-iii: 6.1.19 -> 6.1.20 ``                                               |
| [`7a96b48e`](https://github.com/NixOS/nixpkgs/commit/7a96b48e2aa4f3a9fc7f17dec9d28e994f5b4d30) | `` nixpkgs-review: use python3Packages instead of python3.pkgs to fix splicing `` |
| [`2e913231`](https://github.com/NixOS/nixpkgs/commit/2e913231ee30600d7acb5cc54ff0a435468d934f) | `` nixpkgs-review: modernize ``                                                   |
| [`5afabbdc`](https://github.com/NixOS/nixpkgs/commit/5afabbdc4eed31eb2ce31438b55964ed47320659) | `` libretro.fceumm: unstable-2024-07-20 -> unstable-2024-09-23 ``                 |
| [`75fc5f59`](https://github.com/NixOS/nixpkgs/commit/75fc5f59bc630bc6264e50c7fc1e8d08d15a47f9) | `` v2raya: 2.2.5.6 -> 2.2.5.8 ``                                                  |
| [`5f603b64`](https://github.com/NixOS/nixpkgs/commit/5f603b64034f76fed45250dd7eeb93fb3000380a) | `` libretro.flycast: unstable-2024-09-16 -> unstable-2024-09-27 ``                |
| [`1c0ff987`](https://github.com/NixOS/nixpkgs/commit/1c0ff9871daea489d851dfba1574745b0ad6fd84) | `` libretro.genesis-plus-gx: unstable-2024-09-15 -> unstable-2024-09-18 ``        |
| [`72b6eada`](https://github.com/NixOS/nixpkgs/commit/72b6eada2d8c9eada0b3b68e40725336e8aaabfa) | `` nixpkgs-review: format with nixfmt ``                                          |
| [`056fc213`](https://github.com/NixOS/nixpkgs/commit/056fc213e602dfacfb79c637382d9202ecc29d64) | `` modules/obs-studio: optionally enable v4l2loopback (#312112) ``                |