### PR TITLE
chore(flake/nur): `bb4818cf` -> `01c22fb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727741153,
-        "narHash": "sha256-f1W7tqpk9oUyALhb4JjZaKQVCreiZbaZxMiX4sWeBBM=",
+        "lastModified": 1727779756,
+        "narHash": "sha256-KLeROOi6VYct8lP1TIAPABlKOsisecKZLOozD5W54PE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bb4818cf574dcabcc29fbcb48b43339187a5d5cb",
+        "rev": "01c22fb0d5c07a4a2f9ffc4b132cfa4ee4e1cce2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`01c22fb0`](https://github.com/nix-community/NUR/commit/01c22fb0d5c07a4a2f9ffc4b132cfa4ee4e1cce2) | `` automatic update `` |
| [`e134a9da`](https://github.com/nix-community/NUR/commit/e134a9da6905594310ae3c6e1fdf2cad431a6010) | `` automatic update `` |
| [`8ebf31ca`](https://github.com/nix-community/NUR/commit/8ebf31ca60f67e29f34ad59f36a6646bef644096) | `` automatic update `` |
| [`8e9e3acd`](https://github.com/nix-community/NUR/commit/8e9e3acd35834647123b8fb8f787e03aa1cc7f4f) | `` automatic update `` |
| [`3151bec8`](https://github.com/nix-community/NUR/commit/3151bec84bc8f16a571bacf903dc634de20f3ea7) | `` automatic update `` |
| [`f2aa4aa7`](https://github.com/nix-community/NUR/commit/f2aa4aa7a1fe192fb740c65d03ea728d9e933ca1) | `` automatic update `` |
| [`cfd6450b`](https://github.com/nix-community/NUR/commit/cfd6450b4bb908d74c9889f93714e999ebdbef04) | `` automatic update `` |
| [`48392ca5`](https://github.com/nix-community/NUR/commit/48392ca53e9a278cfaedc14efaabc08a6b16cbc9) | `` automatic update `` |
| [`2540506a`](https://github.com/nix-community/NUR/commit/2540506ad825f3f9992e1f18de13fe968649cb20) | `` automatic update `` |
| [`43a52625`](https://github.com/nix-community/NUR/commit/43a52625e41896d5848f24a5c3c100c4a5759486) | `` automatic update `` |
| [`1346be93`](https://github.com/nix-community/NUR/commit/1346be9304c3aa5e20c436178578ead7e4f0c664) | `` automatic update `` |
| [`f359680f`](https://github.com/nix-community/NUR/commit/f359680f449d52bd15a3a9cbd52ff02286dcb592) | `` automatic update `` |
| [`11556e29`](https://github.com/nix-community/NUR/commit/11556e2959e8a477ccb418b4497e8926bde99134) | `` automatic update `` |
| [`43b9fe7a`](https://github.com/nix-community/NUR/commit/43b9fe7a67b18e7f949edd6095c297f15bc9cb3b) | `` automatic update `` |
| [`cc6d2787`](https://github.com/nix-community/NUR/commit/cc6d2787890d8f9cc32bade21a831152db0344a2) | `` automatic update `` |
| [`f96100ca`](https://github.com/nix-community/NUR/commit/f96100ca4b03576b1f209d18b863bbc42052539a) | `` automatic update `` |
| [`0439aa6b`](https://github.com/nix-community/NUR/commit/0439aa6b1dd44d8d3e2cb04f3e1c8fb93d37e7b9) | `` automatic update `` |
| [`b62ab05c`](https://github.com/nix-community/NUR/commit/b62ab05cd5daafdeedbe541d2a400e99034c2461) | `` automatic update `` |
| [`8fc06a88`](https://github.com/nix-community/NUR/commit/8fc06a8843501563c94c91a2ffafaccea2ca79f4) | `` automatic update `` |
| [`47a53673`](https://github.com/nix-community/NUR/commit/47a536730d6baed3f2611409eee4a41901f52dfc) | `` automatic update `` |
| [`77670c2b`](https://github.com/nix-community/NUR/commit/77670c2b3c7e8bfb783c888a37e2c30203461916) | `` automatic update `` |
| [`2c487011`](https://github.com/nix-community/NUR/commit/2c4870114810f2cfabfa36dc6e828425739f6719) | `` automatic update `` |
| [`b13fd6bd`](https://github.com/nix-community/NUR/commit/b13fd6bd14c3d6b4b36009d0415f202c00eef8d0) | `` automatic update `` |
| [`c1c35b06`](https://github.com/nix-community/NUR/commit/c1c35b062b938b68cd0a2951a982e057526d3c50) | `` automatic update `` |
| [`513232c3`](https://github.com/nix-community/NUR/commit/513232c330e92795cfbd31cba42f08ea5c2e1615) | `` automatic update `` |