### PR TITLE
chore(flake/nix-vscode-extensions): `2e883749` -> `718a9b94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727747703,
-        "narHash": "sha256-YbKSShfCRNC4edx39kagpdpMYgu21L4f+sMStDI5rjc=",
+        "lastModified": 1727833615,
+        "narHash": "sha256-C/9XuEGFtCEVToOfY7JU/CVMa6AcluPGLW6krNDS0HQ=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "2e8837496c0f58c4342ed84d309a8bc57677bc41",
+        "rev": "718a9b948796e17ae2bfff11f023e2b2894e072d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message      |
| -------------------------------------------------------------------------------------------------------------------- | ------------ |
| [`718a9b94`](https://github.com/nix-community/nix-vscode-extensions/commit/718a9b948796e17ae2bfff11f023e2b2894e072d) | `` action `` |