### PR TITLE
chore(flake/hyprland): `5c6c300a` -> `e2426942`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1727714556,
-        "narHash": "sha256-yKUacj9xjVg0QSXuVoEzbLR6D3pao+jGF0wVc8BYQz0=",
+        "lastModified": 1727860939,
+        "narHash": "sha256-hAoVMQo+DIkuLCWSCqhxgyGMbkLfmmKandjV69Hlpek=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5c6c300abfea2539ffad9bcbf857325eec5ab765",
+        "rev": "e2426942e5716a742ea353d2a1de7d7760fbbb41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                          |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`e2426942`](https://github.com/hyprwm/Hyprland/commit/e2426942e5716a742ea353d2a1de7d7760fbbb41) | `` layout: add auto_group to control default grouping (#7883) `` |