### PR TITLE
chore(flake/spicetify-nix): `f190dd95` -> `3e033244`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727756255,
-        "narHash": "sha256-C+Gmw5CsUXel9T/UYA+QEJPjF8m+2clv3uiKEVCSkNs=",
+        "lastModified": 1727842659,
+        "narHash": "sha256-2m5hx16ayKSvRFQyHDfRXMWVZDyDpI3DMwr7ujf+3tg=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "f190dd954b30e6830939fb764cac85c773846435",
+        "rev": "3e033244348288c6995b155a493a229e499a7c4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`3e033244`](https://github.com/Gerg-L/spicetify-nix/commit/3e033244348288c6995b155a493a229e499a7c4f) | `` CI update 2024-10-02 `` |