### PR TITLE
chore(flake/nur): `2eaa6a4b` -> `18f1593e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1727999300,
-        "narHash": "sha256-y18q4rFuWZ5z1OllpZnNGtYZfIWPYta8V3MI+liB+d8=",
+        "lastModified": 1728040000,
+        "narHash": "sha256-VUSogQheLmVec/EP3rxmopXJOwg7GAuWbxt5uJzTo88=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2eaa6a4b8f589bc82805ec76506e9264e3acec9a",
+        "rev": "18f1593e31a3df732df20252a5b18b3e866d77f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`18f1593e`](https://github.com/nix-community/NUR/commit/18f1593e31a3df732df20252a5b18b3e866d77f8) | `` automatic update `` |
| [`370762a6`](https://github.com/nix-community/NUR/commit/370762a6f84c92b147538b2b1843947cd3193c08) | `` automatic update `` |
| [`53f28176`](https://github.com/nix-community/NUR/commit/53f281767c5700f76f7d49c3c34936f989e26512) | `` automatic update `` |
| [`2eda69b6`](https://github.com/nix-community/NUR/commit/2eda69b6d70f2564f95a7b5c41c00b3ac0307ef5) | `` automatic update `` |
| [`c9c5e4e5`](https://github.com/nix-community/NUR/commit/c9c5e4e57b475f94fa0ba622611428b8fa3bd1cc) | `` automatic update `` |
| [`414647e4`](https://github.com/nix-community/NUR/commit/414647e437d9f790b03d5feed395220b0c91acc6) | `` automatic update `` |
| [`ca64f970`](https://github.com/nix-community/NUR/commit/ca64f9708edc459bf5879a4138274fceeb634f65) | `` automatic update `` |
| [`7e2765d6`](https://github.com/nix-community/NUR/commit/7e2765d6cfcfa0710319243da6edf6a418a13384) | `` automatic update `` |
| [`f8c836cc`](https://github.com/nix-community/NUR/commit/f8c836cc55ab102582a5b293ddc8daf4e2379a1e) | `` automatic update `` |
| [`1aeca4ba`](https://github.com/nix-community/NUR/commit/1aeca4bacb749ad3ef8d9445e144cfee6273a31e) | `` automatic update `` |
| [`276d07b1`](https://github.com/nix-community/NUR/commit/276d07b1660a75f50d7055b732b00521dba11c65) | `` automatic update `` |
| [`9bcae303`](https://github.com/nix-community/NUR/commit/9bcae303eee306a80d5b064bfe09ec9d883ab286) | `` automatic update `` |
| [`9bb2df69`](https://github.com/nix-community/NUR/commit/9bb2df699302cdfb79bda55c62d86b95369194fe) | `` automatic update `` |