### PR TITLE
chore(flake/home-manager): `437ec620` -> `509dbf8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727817100,
-        "narHash": "sha256-dlyV9/eiWkm/Y/t2+k4CFZ29tBvCANmJogEYaHeAOTw=",
+        "lastModified": 1728041527,
+        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "437ec62009fa8ceb684eb447d455ffba25911cf9",
+        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`509dbf8d`](https://github.com/nix-community/home-manager/commit/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e) | `` megasync: fix issue with service failing to launch ``     |
| [`30e04f3d`](https://github.com/nix-community/home-manager/commit/30e04f3d477256de3eb6a7cff608e220087537d4) | `` pass-secret-service: add GNUPGHOME to service env vars `` |