### PR TITLE
chore(flake/nix-vscode-extensions): `43482ab1` -> `018196c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1728092750,
-        "narHash": "sha256-N3v1gy/DQ6CBV0izEqG+WJvH+k+nsuUy5cfg1h7JawQ=",
+        "lastModified": 1728179514,
+        "narHash": "sha256-mOGZFPYm9SuEXnYiXhgs/JmLu7RofRaMpAYyJiWudkc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "43482ab1bc35a4cf504d078771804f181c15293c",
+        "rev": "018196c371073d669510fd69dd2f6dc0ec608c41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message      |
| -------------------------------------------------------------------------------------------------------------------- | ------------ |
| [`018196c3`](https://github.com/nix-community/nix-vscode-extensions/commit/018196c371073d669510fd69dd2f6dc0ec608c41) | `` action `` |