### PR TITLE
chore(flake/nur): `a62be009` -> `e6ad3593`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1728172201,
-        "narHash": "sha256-lnOa4tP0Kf/KtYblBKYGJjLf55U9f5HftyE0ZSFGnpw=",
+        "lastModified": 1728215254,
+        "narHash": "sha256-z/fDpgmuRI/X3h74cGph7DU0VEBC8VWcrKY8AdTVABw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a62be00984c8eb457368bda73fa0c24949360743",
+        "rev": "e6ad3593324e2a96526177ec7c3041ea97bf6946",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e6ad3593`](https://github.com/nix-community/NUR/commit/e6ad3593324e2a96526177ec7c3041ea97bf6946) | `` automatic update `` |
| [`6faaf492`](https://github.com/nix-community/NUR/commit/6faaf492c4d987c06dc6dd4bc8ddad91afc28789) | `` automatic update `` |
| [`1edcc31b`](https://github.com/nix-community/NUR/commit/1edcc31bb5ec6006e1d3021f30de2a04f24a89ca) | `` automatic update `` |
| [`882ce566`](https://github.com/nix-community/NUR/commit/882ce566122ca45ad2f00ad868bfec184923d9db) | `` automatic update `` |
| [`70008a4a`](https://github.com/nix-community/NUR/commit/70008a4adf040d35fc08357d1170771c3761539b) | `` automatic update `` |
| [`c5ce696d`](https://github.com/nix-community/NUR/commit/c5ce696d91a26412f6b99f9f76f271ad23997ec7) | `` automatic update `` |
| [`8b815a8a`](https://github.com/nix-community/NUR/commit/8b815a8afeb4b52667ccefb3487a2ccf5c4162ec) | `` automatic update `` |
| [`041a9b3e`](https://github.com/nix-community/NUR/commit/041a9b3e67afed4b6913eb02b02dc8485f3652b5) | `` automatic update `` |
| [`1841d27c`](https://github.com/nix-community/NUR/commit/1841d27c08fb58b1bb3e7944711938e719dd532e) | `` automatic update `` |
| [`32e6c482`](https://github.com/nix-community/NUR/commit/32e6c482d09d92ef4b27a5b713b5b17a6c7b2b6b) | `` automatic update `` |