### PR TITLE
chore(flake/spicetify-nix): `277107c2` -> `f532f68a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728101832,
-        "narHash": "sha256-0cRtOtkcQvhcKq0vx2C/2uOVUlOmJNZQzcZiK581wto=",
+        "lastModified": 1728188225,
+        "narHash": "sha256-3Mf0XHpECwSxVDb7VYmiD7mqcMA3FcVVfqs3LLZHdaA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "277107c2bc07582899d53e7fc901e93126d944bd",
+        "rev": "f532f68a72549f8ee585aa2f6f7dbe9e2ce5a45c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`f532f68a`](https://github.com/Gerg-L/spicetify-nix/commit/f532f68a72549f8ee585aa2f6f7dbe9e2ce5a45c) | `` CI update 2024-10-06 `` |