### PR TITLE
chore(flake/hyprland): `b65773be` -> `7564b26b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1728554473,
-        "narHash": "sha256-aL+CiCe33QclUKYfNFgEsl998LeDWJc0Ow4JOm5XB7I=",
+        "lastModified": 1728645556,
+        "narHash": "sha256-anTuia5+9iOJ/N55jaoe/tJCnlGqs1bvQP141xfClgc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "b65773bea9b912a41cfcbc789fb2e60a07e3d0c1",
+        "rev": "7564b26b7d386d248eaa47c1a481c09eefd8e3ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`7564b26b`](https://github.com/hyprwm/Hyprland/commit/7564b26b7d386d248eaa47c1a481c09eefd8e3ca) | `` internal: improve version query and define HYPRLAND_VERSION (#8034) `` |
| [`178a300e`](https://github.com/hyprwm/Hyprland/commit/178a300eeaf006fed4c8c9a599657b4530f65559) | `` xwayland: minor cleanups and fixes (#8076) ``                          |
| [`d655a103`](https://github.com/hyprwm/Hyprland/commit/d655a10381f01212635f2eadd69e1f22930f8f06) | `` config/layout: nuke no_gaps_when_only (#8072) ``                       |