### PR TITLE
chore(flake/nur): `0eb5a0ee` -> `1d874e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1728602745,
-        "narHash": "sha256-UcWXwxHP2SX3lJ/XGYQbKu+KKALsPp/BC+3YWfbgOuo=",
+        "lastModified": 1728649449,
+        "narHash": "sha256-A6TaaodFNlxdDrNV7IwpYv5PqjyBSXAGFCVpptRdeIE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0eb5a0ee12c355e8e897e0fe23e1ff9df332a9a6",
+        "rev": "1d874e69d2352f5bdb55843ff3ceaa5978a24da5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d874e69`](https://github.com/nix-community/NUR/commit/1d874e69d2352f5bdb55843ff3ceaa5978a24da5) | `` automatic update `` |
| [`abf82f0f`](https://github.com/nix-community/NUR/commit/abf82f0f0338c25322e0653c2b7e09814da7b2f7) | `` automatic update `` |
| [`249b147c`](https://github.com/nix-community/NUR/commit/249b147c8b96ea9bfc873723f82f88f61f685bb0) | `` automatic update `` |
| [`fc80a73f`](https://github.com/nix-community/NUR/commit/fc80a73f0318005f8f9c9193a6c62ea0469276d1) | `` automatic update `` |
| [`618dfe39`](https://github.com/nix-community/NUR/commit/618dfe39a021baf2c2d83967d7e1ae0acd5ce3a0) | `` automatic update `` |
| [`8e431a6e`](https://github.com/nix-community/NUR/commit/8e431a6efe584fded01024cbf5d542e9d2f6ae41) | `` automatic update `` |
| [`d8e9959e`](https://github.com/nix-community/NUR/commit/d8e9959edb7a7a43319abbe1a8d406855910e769) | `` automatic update `` |
| [`c8317249`](https://github.com/nix-community/NUR/commit/c831724934d736e4c99c68a2a407df3f387f701b) | `` automatic update `` |
| [`f636a69b`](https://github.com/nix-community/NUR/commit/f636a69b74c9093ddf2b17337eda26e799127216) | `` automatic update `` |
| [`a376036c`](https://github.com/nix-community/NUR/commit/a376036c84f23618c21198ff490e314203e64dd5) | `` automatic update `` |
| [`cc39cf20`](https://github.com/nix-community/NUR/commit/cc39cf204262c358a8dc7fa18b68a4ed0b8eca7b) | `` automatic update `` |