### PR TITLE
chore(flake/home-manager): `2b13611e` -> `d57112db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728685293,
-        "narHash": "sha256-1WowL96pksT/XCi+ZXHgqiQ9NiU5oxWuNIQYWqOoEYc=",
+        "lastModified": 1728726232,
+        "narHash": "sha256-8ZWr1HpciQsrFjvPMvZl0W+b0dilZOqXPoKa2Ux36bc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2b13611eaed8326789f76f70d21d06fbb14e3e47",
+        "rev": "d57112db877f07387ce7104b5ac346ede556d2d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`d57112db`](https://github.com/nix-community/home-manager/commit/d57112db877f07387ce7104b5ac346ede556d2d7) | `` pls: fixed perm argument to pass via pls `` |