### PR TITLE
chore(flake/hyprland): `ee8116ac` -> `1822707c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1728692991,
-        "narHash": "sha256-DrMSbUJ8fEJcXYhEnoziRVSV+UVo4DyCQwaPXfHhpKw=",
+        "lastModified": 1728752206,
+        "narHash": "sha256-Eid2nnuw318Vra/+FFdmQpQ50Kc60u8HFn4qwxf9mFc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "ee8116ac5dc412dce924a0163074ce7988dd0cfc",
+        "rev": "1822707c7e7394ce8c7572f2fe890763a307f499",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`1822707c`](https://github.com/hyprwm/Hyprland/commit/1822707c7e7394ce8c7572f2fe890763a307f499) | `` drm-syncobj: fix crash on missing timelines ``            |
| [`c3f7c9bb`](https://github.com/hyprwm/Hyprland/commit/c3f7c9bbb52b9ad3d24ccfcc5c552ed16c9985a5) | `` xcursor: don't crash on broken permissions in X themes `` |