### PR TITLE
chore(flake/nur): `79466d1c` -> `c6b7ef33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1728728489,
-        "narHash": "sha256-qq0IzZ2I56156aezqbhXCiDF4Qr1Oxamw4s+vCYhqeg=",
+        "lastModified": 1728778053,
+        "narHash": "sha256-cMrvP6KtU70EZXJaG60ASzjia1CoEKN1UuX5BpS93Uw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "79466d1c9bac4f779dd10a06deb7cae51be4540e",
+        "rev": "c6b7ef33feea3c22ef420ebdf97f547a34d16adf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c6b7ef33`](https://github.com/nix-community/NUR/commit/c6b7ef33feea3c22ef420ebdf97f547a34d16adf) | `` automatic update `` |
| [`af31ea38`](https://github.com/nix-community/NUR/commit/af31ea380af72ca02bfa657e7ffcde5538c71e73) | `` automatic update `` |
| [`2783ec9a`](https://github.com/nix-community/NUR/commit/2783ec9ab9ea630d8f7657bee76cef81e0c125e6) | `` automatic update `` |
| [`dfb94a40`](https://github.com/nix-community/NUR/commit/dfb94a4063e762fb282b91af80bff1ad1ddeb27f) | `` automatic update `` |
| [`0d5a8437`](https://github.com/nix-community/NUR/commit/0d5a843741d2c551f3023bff528f236ec0dfe9d0) | `` automatic update `` |
| [`77dee3b7`](https://github.com/nix-community/NUR/commit/77dee3b793031fe59928b41400ae01f5b94f8dfd) | `` automatic update `` |
| [`3d61bf1e`](https://github.com/nix-community/NUR/commit/3d61bf1e80027aa8720b0976f60da66c475079d3) | `` automatic update `` |
| [`457a1663`](https://github.com/nix-community/NUR/commit/457a1663803672cfbac64dcdab7f66717894f485) | `` automatic update `` |
| [`f0a7ff1d`](https://github.com/nix-community/NUR/commit/f0a7ff1d331bc6f21323decaab2565603b5b4376) | `` automatic update `` |
| [`6723f290`](https://github.com/nix-community/NUR/commit/6723f290f06d903352ec0465d875138f707a8fdd) | `` automatic update `` |
| [`ff5a2aa7`](https://github.com/nix-community/NUR/commit/ff5a2aa7b8de7d35932c6e22f48fa2d4ba013838) | `` automatic update `` |
| [`4293bf4c`](https://github.com/nix-community/NUR/commit/4293bf4c0d6da26298350af7fff8800fb59d9b77) | `` automatic update `` |