### PR TITLE
chore(flake/nixpkgs): `4c2fcb09` -> `1997e4aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,10 +23,22 @@
     },
     "aquamarine": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728902391,
@@ -59,7 +71,10 @@
     },
     "darwin": {
       "inputs": {
-        "nixpkgs": ["agenix", "nixpkgs"]
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1700795494,
@@ -79,7 +94,9 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
@@ -214,7 +231,11 @@
     },
     "gitignore": {
       "inputs": {
-        "nixpkgs": ["hyprland", "pre-commit-hooks", "nixpkgs"]
+        "nixpkgs": [
+          "hyprland",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1709087332,
@@ -232,7 +253,10 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": ["agenix", "nixpkgs"]
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1703113217,
@@ -250,7 +274,9 @@
     },
     "home-manager_2": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1729459288,
@@ -268,9 +294,18 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": ["hyprland", "hyprlang"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728669738,
@@ -315,8 +350,14 @@
     },
     "hyprland-protocols": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728345020,
@@ -334,9 +375,18 @@
     },
     "hyprlang": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728168612,
@@ -354,8 +404,14 @@
     },
     "hyprutils": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728941256,
@@ -373,8 +429,14 @@
     },
     "hyprwayland-scanner": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1726874836,
@@ -392,7 +454,9 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1729394935,
@@ -514,11 +578,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1729413321,
+        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
         "type": "github"
       },
       "original": {
@@ -563,7 +627,10 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": ["hyprland", "nixpkgs"],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -598,7 +665,9 @@
     "spicetify-nix": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1729484282,
@@ -676,12 +745,30 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": ["hyprland", "hyprland-protocols"],
-        "hyprlang": ["hyprland", "hyprlang"],
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728166987,


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`0653083b`](https://github.com/NixOS/nixpkgs/commit/0653083b486f897a5794d9d9cb888735b4ff4083) | `` yggdrasil: 0.5.8 -> 0.5.9 ``                                                  |
| [`3ca92ac2`](https://github.com/NixOS/nixpkgs/commit/3ca92ac2258051f7b2e8baca65aeaa1e4a9149c8) | `` global-platform-pro: 20.01.23 -> 24.10.15 ``                                  |
| [`23c4c195`](https://github.com/NixOS/nixpkgs/commit/23c4c1954152235eea57502366dab58ac6e49899) | `` monetdb: 11.49.11 -> 11.51.3 ``                                               |
| [`cc080216`](https://github.com/NixOS/nixpkgs/commit/cc080216d3108ee0f4bc66bdc0c148407eebcd87) | `` netbird: 0.30.0 -> 0.30.2 ``                                                  |
| [`c3e24364`](https://github.com/NixOS/nixpkgs/commit/c3e243641cc893a1c005ebe09c00319fef20ee88) | `` libthreadar: 1.4.0 -> 1.5.0 ``                                                |
| [`64d3fc6e`](https://github.com/NixOS/nixpkgs/commit/64d3fc6e4f7333e5c3fa91bd5e19a56bbb378997) | `` waycorner: add missing updateScript ``                                        |
| [`470908bd`](https://github.com/NixOS/nixpkgs/commit/470908bd5d24fb7dd555849d24dffa6e17350738) | `` pipet: 0.2.2 -> 0.3.0 ``                                                      |
| [`14cdc1df`](https://github.com/NixOS/nixpkgs/commit/14cdc1dfb008996aa0b339ff5aeeb9af0331f431) | `` eksctl: 0.191.0 -> 0.193.0 ``                                                 |
| [`babd3fd2`](https://github.com/NixOS/nixpkgs/commit/babd3fd21cf4a95ed5c07fd41f93a4d88b399359) | `` python312Packages.pyais: 2.8.0 -> 2.8.1 ``                                    |
| [`e72ffb73`](https://github.com/NixOS/nixpkgs/commit/e72ffb739e048120772314100169d3033626e555) | `` python312Packages.eq3btsmart: 1.1.9 -> 1.2.0 ``                               |
| [`c19599e3`](https://github.com/NixOS/nixpkgs/commit/c19599e33de9a9efd59c8d0441e71883d92a0b58) | `` spacectl: 1.5.0 -> 1.6.0 ``                                                   |
| [`e3371313`](https://github.com/NixOS/nixpkgs/commit/e33713134923c0f0d593597cd76086c36f4facf4) | `` linux-firmware: fix build when cross-compiling ``                             |
| [`882ec7cb`](https://github.com/NixOS/nixpkgs/commit/882ec7cbd959f82eb2be23f9e3a460d9f8fa926d) | `` maintainers: add mrgiles ``                                                   |
| [`9db2b2e4`](https://github.com/NixOS/nixpkgs/commit/9db2b2e4411aaac25c210cfca005943706d81e54) | `` tellico: use stdenv.mkDerivation ``                                           |
| [`61dab424`](https://github.com/NixOS/nixpkgs/commit/61dab424a56efd008508bed9db90816f6da4db28) | `` vimPlugins.unimpaired-nvim: init at 2024-10-17 ``                             |
| [`c33a48f4`](https://github.com/NixOS/nixpkgs/commit/c33a48f49c82072334dad3c6f5a435832348e8fa) | `` vimPlugins.cmp-nixpkgs-maintainers: 2024-10-15 -> 2024-10-19 ``               |
| [`a1cba1a4`](https://github.com/NixOS/nixpkgs/commit/a1cba1a4a1fb971dba2ac3679cefa0e235da6c69) | `` river-bsp-layout: init at 2.1.0 ``                                            |
| [`7c26ba2d`](https://github.com/NixOS/nixpkgs/commit/7c26ba2dfd4bb8fd164a65609d034d8c0a18e040) | `` termineter: init at 1.0.6 ``                                                  |
| [`afd4fc1d`](https://github.com/NixOS/nixpkgs/commit/afd4fc1db1b75c49ac6359366713a72a20f07792) | `` python312Packages.smoke-zephyr: init at 2.0.1 ``                              |
| [`dd59dfe8`](https://github.com/NixOS/nixpkgs/commit/dd59dfe8dc6932087e887d7fa168069666de5b42) | `` python312Packages.crcelk: init at 1.3 ``                                      |
| [`ed4014cd`](https://github.com/NixOS/nixpkgs/commit/ed4014cdecb8d73d4fed22a087a22159ec094b2a) | `` python312Packages.griffe: 1.4.1 -> 1.5.1 ``                                   |
| [`92da05ac`](https://github.com/NixOS/nixpkgs/commit/92da05ac54bb5ef8870ccbf295ab7c1a5e2b9e08) | `` python312Packages.python-registry: refactor ``                                |
| [`75ed9ddb`](https://github.com/NixOS/nixpkgs/commit/75ed9ddb97c486cc4d3bc6d6c6b36a543dc8fd8f) | `` python312Packages.types-html5lib: 1.1.11.20240806 -> 1.1.11.20241018 ``       |
| [`fa96f9d6`](https://github.com/NixOS/nixpkgs/commit/fa96f9d63c4ffbb11d678ccbe1308c49b272fc4a) | `` helmfile-wrapped: 0.168.0 -> 0.169.0 ``                                       |
| [`41ce8a16`](https://github.com/NixOS/nixpkgs/commit/41ce8a16c1286229b8331d984674de3148aaa58a) | `` helmfile: 0.168.0 -> 0.169.0 ``                                               |
| [`2956005d`](https://github.com/NixOS/nixpkgs/commit/2956005d4bc9aedd4dc199b445a2abb887c1b964) | `` tinymist: 0.11.32 -> 0.12.0 ``                                                |
| [`4f65ffa2`](https://github.com/NixOS/nixpkgs/commit/4f65ffa29edaa5894971743bba7219e30e71bc04) | `` python312Packages.robotframework: 7.1 -> 7.1.1 ``                             |
| [`0065f778`](https://github.com/NixOS/nixpkgs/commit/0065f778752685fca1be1df542ff13ddc42bd32e) | `` python312Packages.mplhep-data: 0.0.3 -> 0.0.4 ``                              |
| [`8ac75ddb`](https://github.com/NixOS/nixpkgs/commit/8ac75ddb6f41ae59ef1bc422e49ad0b17d586250) | `` kdePackages.kunifiedpush: unstable -> 1.0.0, enable by default on Plasma 6 `` |
| [`76c7c2dd`](https://github.com/NixOS/nixpkgs/commit/76c7c2dd88be617a8a9fdda78f2845eafbb40088) | `` nodePackages.shout: drop ``                                                   |
| [`a3af944d`](https://github.com/NixOS/nixpkgs/commit/a3af944d24a9b714e187f3d70cbd391bfa9ae687) | `` python312Packages.ha-ffmpeg: 3.2.0 -> 3.2.1 ``                                |
| [`c5eb288c`](https://github.com/NixOS/nixpkgs/commit/c5eb288cc7c4ef49f10edf4a393b61c8d57dbf18) | `` python312Packages.triton-bin: 2.1.0 -> 3.1.0 ``                               |
| [`5d6337c7`](https://github.com/NixOS/nixpkgs/commit/5d6337c790eae50ba59eddf0ba35798fdd97d628) | `` tocpdf: 0.3.3 -> 0.3.9 ``                                                     |
| [`cc1aeb4f`](https://github.com/NixOS/nixpkgs/commit/cc1aeb4fbd903132ee2203c21b047d812439edf9) | `` nixos/docs: add services.cyrus-imap to rl-2411 ``                             |
| [`8d90446d`](https://github.com/NixOS/nixpkgs/commit/8d90446d39dba6ce3f1f15af5430a4e2ce368f16) | `` nixos/cyrus-imap: init module ``                                              |
| [`8671d601`](https://github.com/NixOS/nixpkgs/commit/8671d601edd7871417c82a539f35e51f8cb0c904) | `` deno: 2.0.0 -> 2.0.2 ``                                                       |
| [`7a020d9d`](https://github.com/NixOS/nixpkgs/commit/7a020d9dc33053fc630a38b88cec81d870fb595f) | `` cyrus-imapd: init at 3.10.0 ``                                                |
| [`9945a902`](https://github.com/NixOS/nixpkgs/commit/9945a9027ba88c33c86f04b817daf38451e8946f) | `` connman: 1.42 -> 1.43 ``                                                      |
| [`d85e141f`](https://github.com/NixOS/nixpkgs/commit/d85e141f064dccc1407c8510a6a01fc6085f99ec) | `` python312Packages.spotifyaio: 0.6.0 -> 0.7.0 ``                               |
| [`ffcfc42d`](https://github.com/NixOS/nixpkgs/commit/ffcfc42d4435d09c2c7e56da5564409518dd1871) | `` goose-lang: init at 0.9.1 ``                                                  |
| [`55219f08`](https://github.com/NixOS/nixpkgs/commit/55219f08a21beea57e354c66d0d50dc722f4e67c) | `` desed: add nix-update-script ``                                               |
| [`e2d68581`](https://github.com/NixOS/nixpkgs/commit/e2d6858147926918ccf124e3a5b24311e37ea330) | `` desed: improve description ``                                                 |
| [`3b50cae2`](https://github.com/NixOS/nixpkgs/commit/3b50cae2b01005c1505c64c67b6ecdfe5719e156) | `` desed: 1.2.1-unstable-2024-09-06 -> 1.2.2 ``                                  |
| [`21c852ee`](https://github.com/NixOS/nixpkgs/commit/21c852eea4319e9d11aebe214c9019a563aaca2d) | `` obs-studio-plugins.obs-source-record: 0.3.4 -> 0.3.5 ``                       |
| [`db3e7ba8`](https://github.com/NixOS/nixpkgs/commit/db3e7ba816f1fc13762a893b4c89cb8190ee1085) | `` kdePackages.qtpbfimageplugin: 3.1 -> 3.2 ``                                   |
| [`9746e073`](https://github.com/NixOS/nixpkgs/commit/9746e073f70023c6d363eeaa23e21d5feb4071ac) | `` level-zero: 1.17.45 -> 1.18.3 ``                                              |
| [`d5ed4f8d`](https://github.com/NixOS/nixpkgs/commit/d5ed4f8d7f59d56570ffb1cd404492acc4c2c4d0) | `` speakersafetyd: 1.0.0 -> 1.0.2 ``                                             |
| [`bff72c17`](https://github.com/NixOS/nixpkgs/commit/bff72c175e954e53706d2db80dc9d46a32ea325f) | `` await: add basic version test ``                                              |
| [`165cacc2`](https://github.com/NixOS/nixpkgs/commit/165cacc280ea5d357e8e7410f25e336518e72ac9) | `` python312Packages.tencentcloud-sdk-python: 3.0.1251 -> 3.0.1252 ``            |
| [`8994a85f`](https://github.com/NixOS/nixpkgs/commit/8994a85f1055ec56248af1457f3589eac92b8ad4) | `` python312Packages.nibe: 2.12.0 -> 2.13.0 ``                                   |
| [`c56ce4fe`](https://github.com/NixOS/nixpkgs/commit/c56ce4fe5e8e15e750412805b44793632f0fefff) | `` python312Packages.publicsuffixlist: 1.0.2.20241017 -> 1.0.2.20241019 ``       |
| [`0e61a72a`](https://github.com/NixOS/nixpkgs/commit/0e61a72a22554c16965d36130540f56fb045dea5) | `` python312Packages.meshtastic: 2.5.2 -> 2.5.3 ``                               |
| [`a9c9efc9`](https://github.com/NixOS/nixpkgs/commit/a9c9efc92238986885089b921ae7a3b27dedbb99) | `` bitcomet: init at 2.10.0 ``                                                   |
| [`56283948`](https://github.com/NixOS/nixpkgs/commit/56283948728e083a46679aa9b3a122acf7b5a2b8) | `` python312Packages.plugwise: 1.4.2 -> 1.4.3 ``                                 |
| [`b090ba05`](https://github.com/NixOS/nixpkgs/commit/b090ba05999fd9222656460352c592f7e0724f63) | `` python312Packages.pysqueezebox: 0.9.4 -> 10.0.0 ``                            |
| [`f3a4421f`](https://github.com/NixOS/nixpkgs/commit/f3a4421f274951117a13c4dc37ab78c2de51bd2c) | `` buildMozillaMach: change tests to an attrset ``                               |
| [`470efda5`](https://github.com/NixOS/nixpkgs/commit/470efda5ce82a286687fa619ddd0a0c81257eb27) | `` clash-geoip: drop ``                                                          |
| [`b388e7b5`](https://github.com/NixOS/nixpkgs/commit/b388e7b5659289aa7bbf51da94c509f63edd0eb9) | `` await: 1.0.2 -> 1.0.5 ``                                                      |
| [`a70f40d0`](https://github.com/NixOS/nixpkgs/commit/a70f40d09cc9f8b78f4d47f2783fe9d69940815d) | `` gitxray: 1.0.15-unstable-2024-09-20 -> 1.0.16 ``                              |
| [`acc6846d`](https://github.com/NixOS/nixpkgs/commit/acc6846d25f1dc140fbbd518a3c147e7be33cbb7) | `` python312Packages.aiohomekit: 3.2.3 -> 3.2.4 ``                               |
| [`fcc185b9`](https://github.com/NixOS/nixpkgs/commit/fcc185b9863251246b8f7cbe819fce4279e7241a) | `` nixos/bitmagnet: add help text for the options, fix typo ``                   |
| [`3a4fc1a1`](https://github.com/NixOS/nixpkgs/commit/3a4fc1a18321efe1e8e6546f219aa162b407cdcd) | `` nixos: add bitmagnet module to the list ``                                    |
| [`788722ec`](https://github.com/NixOS/nixpkgs/commit/788722ec5feb30f364d6c5e4af5c4db9c305aef3) | `` containerd: 1.7.22 -> 1.7.23 ``                                               |
| [`58a84c67`](https://github.com/NixOS/nixpkgs/commit/58a84c6727dbe95ab32e3a7802a9d7fd30b408e9) | `` bitmagnet: pin Go 1.22 ``                                                     |
| [`0fe576bd`](https://github.com/NixOS/nixpkgs/commit/0fe576bdca46390b6a81770a4b490fa6c7605709) | `` metacubexd: 1.151.0 -> 1.168.0 ``                                             |
| [`6139a810`](https://github.com/NixOS/nixpkgs/commit/6139a8102e99f4153648bbb26d0c01c9ab8809cc) | `` percona-server_8_{0,4}: fix tests not being found ``                          |
| [`aad0a65e`](https://github.com/NixOS/nixpkgs/commit/aad0a65ebf77b1ea1f0ab8b5af0028566192bd9e) | `` podman-desktop: use correct version for changelog ``                          |
| [`b3d9e85d`](https://github.com/NixOS/nixpkgs/commit/b3d9e85d5333e7c142cc6ef318b64994e72ce12d) | `` electrum: migrate to `build-system`/`dependencies` ``                         |
| [`7ab639c5`](https://github.com/NixOS/nixpkgs/commit/7ab639c51e72996a81331cd6615f57bf935ac42f) | `` catppuccin-whiskers: 2.5.0 -> 2.5.1 ``                                        |
| [`45039a67`](https://github.com/NixOS/nixpkgs/commit/45039a6730fc7101363c2f3050dcdb87bf839ac8) | `` snoop: init at 0.4 ``                                                         |
| [`09ff437f`](https://github.com/NixOS/nixpkgs/commit/09ff437fe9b0dd46d7bf5eb38734da96019ba129) | `` Revert "electrum: pin ledger-bitcoin to 0.2.1" ``                             |
| [`d326fa89`](https://github.com/NixOS/nixpkgs/commit/d326fa896f612085d6d9337b1ec69fb31f50fec1) | `` electrum: 4.5.5 -> 4.5.6 ``                                                   |
| [`1841da39`](https://github.com/NixOS/nixpkgs/commit/1841da399fe96f474505c93d1fc5dd82e882606d) | `` python312Packages.lm-format-enforcer: 0.10.7 -> 0.10.9 ``                     |
| [`c25de294`](https://github.com/NixOS/nixpkgs/commit/c25de294d4bc6c3795b9bc81dd219c45e8732128) | `` python312Packages.equinox: 0.11.7 -> 0.11.8 ``                                |
| [`4e8643ac`](https://github.com/NixOS/nixpkgs/commit/4e8643ac1580f3ce6920233581454716fc30a365) | `` pappl: migrate to by-name ``                                                  |
| [`3301bbda`](https://github.com/NixOS/nixpkgs/commit/3301bbda6e7243c7dd43d957a76ae7a46c01260e) | `` forge-mtg: 1.6.57 -> 1.6.65 ``                                                |
| [`3a55c172`](https://github.com/NixOS/nixpkgs/commit/3a55c172e93fbfa8f87f78e93574d9ae2e260160) | `` step-cli: 0.27.4 -> 0.27.5 ``                                                 |
| [`1ecc7fe4`](https://github.com/NixOS/nixpkgs/commit/1ecc7fe442573fea753827afa2219c6cfdd205e1) | `` electrum: fix build with protobuf dependency ``                               |
| [`cd349810`](https://github.com/NixOS/nixpkgs/commit/cd3498101b4a194cb43879018ce0145ea7500f1e) | `` mautrix-whatsapp: 0.10.9 -> 0.11.0 ``                                         |
| [`c41aecf9`](https://github.com/NixOS/nixpkgs/commit/c41aecf9e820f5678e8a50382a068a68625c5547) | `` typstyle: 0.11.35 -> 0.12.0 ``                                                |
| [`eaa5db17`](https://github.com/NixOS/nixpkgs/commit/eaa5db175d538d5b29facabfb771ef4707c04a9e) | `` pylyzer: 0.0.66 -> 0.0.67 ``                                                  |
| [`e4048428`](https://github.com/NixOS/nixpkgs/commit/e4048428cfa48a945ade2c9c1d6fc85416b99bf5) | `` guestfs-tools: drop versioned ocamlPackages ``                                |
| [`7886f6e5`](https://github.com/NixOS/nixpkgs/commit/7886f6e5f1bdac3143f75a55c9f0a90a3994a9f1) | `` libguestfs-with-appliance: warn in case of version mismatch ``                |
| [`36b4d9db`](https://github.com/NixOS/nixpkgs/commit/36b4d9dbb8f37a0a047c0e6255b95e629699f2ee) | `` libguestfs: 1.50.1 -> 1.54.0 ``                                               |
| [`ba1bfda1`](https://github.com/NixOS/nixpkgs/commit/ba1bfda1e810fe05138d310dcf8cc59dea964f8c) | `` libguestfs-appliance: 1.46.0 -> 1.54.0 ``                                     |
| [`51de6959`](https://github.com/NixOS/nixpkgs/commit/51de6959b7d821299c60ee0a2d353f64012325dd) | `` libguestfs: build appliance daemon (guestfsd) ``                              |
| [`3b7a91a9`](https://github.com/NixOS/nixpkgs/commit/3b7a91a990c6311d2513bf1aa23adcf91c39af56) | `` libguestfs: update maintainership ``                                          |
| [`fb822885`](https://github.com/NixOS/nixpkgs/commit/fb822885cb572aa04c32b75d1e107135a93d8558) | `` libguestfs: format with nixfmt-rfc-style ``                                   |
| [`2612971b`](https://github.com/NixOS/nixpkgs/commit/2612971bf13fc8761b3578434b79368e13acba3b) | `` libguestfs: move to by-name ``                                                |
| [`79bb6a73`](https://github.com/NixOS/nixpkgs/commit/79bb6a7391161027c3719ffb2d4cf3876dd78d8f) | `` vimPlugins.blink-cmp: init at 0.3.1 ``                                        |
| [`8552adf4`](https://github.com/NixOS/nixpkgs/commit/8552adf4476b934844e4380513a94555d1bc62c1) | `` maintainer: add balssh ``                                                     |
| [`cf9c82a2`](https://github.com/NixOS/nixpkgs/commit/cf9c82a24236e0cb7847da1823d3b0fae028067c) | `` Update pkgs/by-name/fo/foxmarks/package.nix ``                                |
| [`9a15135f`](https://github.com/NixOS/nixpkgs/commit/9a15135f47aee5017efdf7c2583058b0a104e8ac) | `` ddns-go: 6.7.0 -> 6.7.2 ``                                                    |
| [`d4c4e231`](https://github.com/NixOS/nixpkgs/commit/d4c4e2312ca8d0579b5767fc55f5a9a197abd37e) | `` python312Packages.serpent: refactor ``                                        |
| [`bc3e365f`](https://github.com/NixOS/nixpkgs/commit/bc3e365f83e688cbe789182d7263a68c57b52c0c) | `` paxctl: remove setup hook ``                                                  |
| [`f12c5fd4`](https://github.com/NixOS/nixpkgs/commit/f12c5fd4b8454954a8d03874b8b4d7214c9ca800) | `` mycli: disable checking to fix build ``                                       |
| [`f46ab77b`](https://github.com/NixOS/nixpkgs/commit/f46ab77becc67a84e5306cf864a2b61639656784) | `` nstool: 1.9.1 -> 1.9.2 ``                                                     |
| [`7907bb80`](https://github.com/NixOS/nixpkgs/commit/7907bb800e5f7e1b85e8249a423b09298cbe99f0) | `` nixos/tests/keymap: use tty2 for the VT test ``                               |
| [`77eb05d7`](https://github.com/NixOS/nixpkgs/commit/77eb05d7b3ee1321fe0e17cbf91c21337d3aa0cb) | `` nixos/tests/keymap: cleanup ``                                                |
| [`a008fe5c`](https://github.com/NixOS/nixpkgs/commit/a008fe5c51ff5bcf8083cf5fc87d054d6677f77a) | `` frp: 0.60.0 -> 0.61.0 ``                                                      |
| [`7393c6d8`](https://github.com/NixOS/nixpkgs/commit/7393c6d837a047be4b27bb78a135f79c0597e94b) | `` python312Packages.pure-protobuf: 3.1.2 -> 3.1.3 ``                            |
| [`31abcf57`](https://github.com/NixOS/nixpkgs/commit/31abcf57440edb068b25ad7bf47a9020fdc4e823) | `` maintainers: add paepcke ``                                                   |
| [`85a652a1`](https://github.com/NixOS/nixpkgs/commit/85a652a1810eaddd3bc6671a42b500d756b2a7fa) | `` git-spice: fix x86_64-darwin ``                                               |