### PR TITLE
chore(flake/nur): `762d1ae1` -> `60fcca8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1729721102,
-        "narHash": "sha256-B3UC6BHAgagabUIpXCkTISp4UhsmB5aP4KJvVFa2yn0=",
+        "lastModified": 1729759608,
+        "narHash": "sha256-qH+KQ0GYls+OB9inNRtO7+k4GTtB/1m7mAGX78J/YOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "762d1ae145f5e2279b4e5b673977a77161e0f451",
+        "rev": "60fcca8c5b60a1889b78827890d42100387cdcf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`60fcca8c`](https://github.com/nix-community/NUR/commit/60fcca8c5b60a1889b78827890d42100387cdcf5) | `` automatic update `` |
| [`232725a2`](https://github.com/nix-community/NUR/commit/232725a2d7227ac09e17d3eddcfbd4c51176fb90) | `` automatic update `` |
| [`7b379d1a`](https://github.com/nix-community/NUR/commit/7b379d1ac27df4ec74e0c380397ad382d8be96a8) | `` automatic update `` |
| [`403e35b3`](https://github.com/nix-community/NUR/commit/403e35b3fb60d75e36919ca99d8020f3e75ffe5b) | `` automatic update `` |
| [`f36778e2`](https://github.com/nix-community/NUR/commit/f36778e2e2b4c2c4cfa76b5f559ca90e83110cf8) | `` automatic update `` |
| [`035bf1e9`](https://github.com/nix-community/NUR/commit/035bf1e907924daca3c98932fc46dbab0ed6f7c3) | `` automatic update `` |
| [`3cc40e2f`](https://github.com/nix-community/NUR/commit/3cc40e2fdd9e0a3f334a1d0d6413f8fec545f3f4) | `` automatic update `` |
| [`d77b5f9e`](https://github.com/nix-community/NUR/commit/d77b5f9e9218ec6d64dff0ea0d2b93e5731044ac) | `` automatic update `` |
| [`1afc0375`](https://github.com/nix-community/NUR/commit/1afc03756c1809f11943f5499ea6eae8a0c60f00) | `` automatic update `` |
| [`ae86d05f`](https://github.com/nix-community/NUR/commit/ae86d05f6936f3b688aa8cc50404250fa423b949) | `` automatic update `` |
| [`e3f9509f`](https://github.com/nix-community/NUR/commit/e3f9509f0552a23146d6899e9249fa95e3069a97) | `` automatic update `` |
| [`0099e990`](https://github.com/nix-community/NUR/commit/0099e990be8733a77966bb04eda3ffebc4e8493f) | `` automatic update `` |
| [`9bbe8838`](https://github.com/nix-community/NUR/commit/9bbe88380b16306a042d6c682bf6efe489825676) | `` automatic update `` |
| [`059dbae8`](https://github.com/nix-community/NUR/commit/059dbae84c381cc19579902c237fc2f5fda51f81) | `` automatic update `` |