### PR TITLE
chore(flake/spicetify-nix): `b9d88696` -> `933469d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -670,11 +670,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729657027,
-        "narHash": "sha256-olxRDZg+/cQZQPW9pEcKfyubHEzqvQsGRrQBw9kTBGg=",
+        "lastModified": 1729743437,
+        "narHash": "sha256-MvidoEC3xJA7wp6Fjs15CuJ81uXzRHJK0VRSzNsfzcM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b9d886969141231ca687a915a2c33b3e85c3085c",
+        "rev": "933469d5d0bc50bcc3918aa0f425d68fdd7c0736",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`933469d5`](https://github.com/Gerg-L/spicetify-nix/commit/933469d5d0bc50bcc3918aa0f425d68fdd7c0736) | `` CI update 2024-10-24 `` |