### PR TITLE
chore(flake/spicetify-nix): `933469d5` -> `fd9ae552`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -670,11 +670,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729743437,
-        "narHash": "sha256-MvidoEC3xJA7wp6Fjs15CuJ81uXzRHJK0VRSzNsfzcM=",
+        "lastModified": 1729829883,
+        "narHash": "sha256-Hl7pgMVLHtEU4BfqhGQScllTB+jjWZEumFQB/5esdXA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "933469d5d0bc50bcc3918aa0f425d68fdd7c0736",
+        "rev": "fd9ae55223412b9dc5fedd3e9c3d1d18804577af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`fd9ae552`](https://github.com/Gerg-L/spicetify-nix/commit/fd9ae55223412b9dc5fedd3e9c3d1d18804577af) | `` CI update 2024-10-25 `` |