### PR TITLE
chore(flake/nix-vscode-extensions): `087ec372` -> `0d53b783`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -479,11 +479,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1729734515,
-        "narHash": "sha256-KGE6Exd1NAhTo806QUqK3oCk40L7spjfEpHnrNNkFD4=",
+        "lastModified": 1729820951,
+        "narHash": "sha256-BeKv+LM2eY+6JuUWO/+pJiY2sraudYDtNxOOAwRpGgc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "087ec37265ff1c8641086ee2a51450963494cdeb",
+        "rev": "0d53b7836079cda476fab76bf9becfdd475a5d1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message      |
| -------------------------------------------------------------------------------------------------------------------- | ------------ |
| [`0d53b783`](https://github.com/nix-community/nix-vscode-extensions/commit/0d53b7836079cda476fab76bf9becfdd475a5d1d) | `` action `` |