### PR TITLE
chore(flake/nur): `20a5ac55` -> `7d7cbe07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1729808576,
-        "narHash": "sha256-q1UEWNVn/0DBCfSH+CvmJ1S4+Qk9yY6h6KRgfvOPfRs=",
+        "lastModified": 1729855863,
+        "narHash": "sha256-TEefmNTtVeQpxziZ9PjWkxAkRQexLEsXk22Wj6Q7IQ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "20a5ac55687e9c19d3965387d89dd1ae1449af80",
+        "rev": "7d7cbe07852abdfd4a3bc09cb565e294f3251548",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7d7cbe07`](https://github.com/nix-community/NUR/commit/7d7cbe07852abdfd4a3bc09cb565e294f3251548) | `` automatic update `` |
| [`2e1068ad`](https://github.com/nix-community/NUR/commit/2e1068ad9868845629bdca56df78546182ec3df6) | `` automatic update `` |
| [`5a807a98`](https://github.com/nix-community/NUR/commit/5a807a981707c8bdea38a643b499a9ac4d493132) | `` automatic update `` |
| [`fe1086c1`](https://github.com/nix-community/NUR/commit/fe1086c18a437ff5f5fbb95dc66abbf61e764cbe) | `` automatic update `` |
| [`2b774632`](https://github.com/nix-community/NUR/commit/2b774632c3443bf5c29b95742b8359f3e3f054aa) | `` automatic update `` |
| [`f3f5e401`](https://github.com/nix-community/NUR/commit/f3f5e401faa3fdb51e19388395e3beda2fad5593) | `` automatic update `` |
| [`244968b2`](https://github.com/nix-community/NUR/commit/244968b2d2236e6ef315e445f3ae119d6fd48e56) | `` automatic update `` |
| [`6f557f56`](https://github.com/nix-community/NUR/commit/6f557f568d3a16cda792132ad82e9f0c14ba5ef0) | `` automatic update `` |
| [`6938e49b`](https://github.com/nix-community/NUR/commit/6938e49ba9238a87e00e492de0230f89f8c02707) | `` automatic update `` |
| [`3cdd8098`](https://github.com/nix-community/NUR/commit/3cdd8098f0a45450087b8d0a10b76bb5053f2785) | `` automatic update `` |
| [`59a3076e`](https://github.com/nix-community/NUR/commit/59a3076e4d4f4a643aa3e6bc1408c47de1defb99) | `` automatic update `` |
| [`9de130e0`](https://github.com/nix-community/NUR/commit/9de130e0ba9caa1d892f2967d02cf11b52849b6c) | `` automatic update `` |
| [`1eb22db9`](https://github.com/nix-community/NUR/commit/1eb22db918db05565903eb468865a4572800c0b8) | `` automatic update `` |
| [`daf8486e`](https://github.com/nix-community/NUR/commit/daf8486e74670c80c03b14be59b8a26fa766c236) | `` automatic update `` |
| [`5332dd79`](https://github.com/nix-community/NUR/commit/5332dd79bc3feeab0ded115680b0e3d33752dfec) | `` automatic update `` |
| [`699caac4`](https://github.com/nix-community/NUR/commit/699caac4ffb2f9e844b5f14dfe316d773cbed7c5) | `` automatic update `` |
| [`842334a0`](https://github.com/nix-community/NUR/commit/842334a02d4e0308b8bde4caefdaae3c2593fa33) | `` automatic update `` |
| [`dd9ac829`](https://github.com/nix-community/NUR/commit/dd9ac8297e1c911100cc06af5580271c27b50cc4) | `` automatic update `` |
| [`529ae013`](https://github.com/nix-community/NUR/commit/529ae013dad3eefef33b13b6730e30f5c34566d2) | `` automatic update `` |