### PR TITLE
chore(flake/nur): `917fe0f3` -> `142092eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730076441,
-        "narHash": "sha256-rL9wD3L2s2gkgcHerGHCMezoF425FfA+ZEvTFano8ZU=",
+        "lastModified": 1730240607,
+        "narHash": "sha256-DGDI+iQlPZKfocBab9BY4R/pN2PGIOvHgEEwfxQsh6M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "917fe0f398348a7a3aec3336b07a35d4cbc2d604",
+        "rev": "142092eb842a145ed21ea07425d52e73d72fe856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                  |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`142092eb`](https://github.com/nix-community/NUR/commit/142092eb842a145ed21ea07425d52e73d72fe856) | `` automatic update ``                   |
| [`39324635`](https://github.com/nix-community/NUR/commit/393246354e12f6f09068c87dad6e8bc20be42ecd) | `` automatic update ``                   |
| [`54ad9b9d`](https://github.com/nix-community/NUR/commit/54ad9b9d402140f7dadb9d9de6d9c21ebbcc9072) | `` automatic update ``                   |
| [`0730f292`](https://github.com/nix-community/NUR/commit/0730f292b69a64931ff3775fc78acdcea1e72b95) | `` automatic update ``                   |
| [`447ea147`](https://github.com/nix-community/NUR/commit/447ea147db384850335ecbe0f894f92dc7b963be) | `` automatic update ``                   |
| [`3a938f36`](https://github.com/nix-community/NUR/commit/3a938f36fd6fcd74fce8b5895071c7747b92bbcc) | `` automatic update ``                   |
| [`10b3c0b1`](https://github.com/nix-community/NUR/commit/10b3c0b1e85839e8d2c00661342f8845e5c3486c) | `` automatic update ``                   |
| [`806f4101`](https://github.com/nix-community/NUR/commit/806f4101da89a9fbcafad025d91c091206871594) | `` automatic update ``                   |
| [`ea8e3f4f`](https://github.com/nix-community/NUR/commit/ea8e3f4f12c7205b02be17549d3fb463af2b12d3) | `` automatic update ``                   |
| [`5dc75dc9`](https://github.com/nix-community/NUR/commit/5dc75dc98a61e966fa0e445e8392b3c8ed654416) | `` automatic update ``                   |
| [`daf38fa7`](https://github.com/nix-community/NUR/commit/daf38fa7f3b8602cb94920c251817a31dcb2abc4) | `` automatic update ``                   |
| [`89e33af8`](https://github.com/nix-community/NUR/commit/89e33af8ccfe2275c2c6042034a400ac7500ef60) | `` automatic update ``                   |
| [`d55e02e5`](https://github.com/nix-community/NUR/commit/d55e02e57dd4d433a43a5f1cd0128bcc979eed1d) | `` automatic update ``                   |
| [`ad05c089`](https://github.com/nix-community/NUR/commit/ad05c08986883815c2034222912cf385786d9d55) | `` add nukdokplex repository ``          |
| [`8a4db419`](https://github.com/nix-community/NUR/commit/8a4db419e0daf22a028dac998d698dde2aea817e) | `` automatic update ``                   |
| [`2f45a194`](https://github.com/nix-community/NUR/commit/2f45a19466c448378053ca35cb65810e606bca39) | `` automatic update ``                   |
| [`c2315acf`](https://github.com/nix-community/NUR/commit/c2315acf488a791d97a275dc8dec1c6aa8c2cbc4) | `` add nelonn/nur-packages repository `` |
| [`370eb848`](https://github.com/nix-community/NUR/commit/370eb8489a44f0b13328979be8a3cb0cf3bdf780) | `` automatic update ``                   |
| [`ddb2cd68`](https://github.com/nix-community/NUR/commit/ddb2cd68ef513412f5a0e4ec1027ff052da4f477) | `` automatic update ``                   |
| [`e4f56b46`](https://github.com/nix-community/NUR/commit/e4f56b46d16fc6b7f590792f34637d5e1786b6bc) | `` automatic update ``                   |
| [`aff6965a`](https://github.com/nix-community/NUR/commit/aff6965a8bc9d16a758a45313427b3b5198e3550) | `` automatic update ``                   |
| [`30ccca6b`](https://github.com/nix-community/NUR/commit/30ccca6b4b5d627314d89cf437cc54a788393407) | `` automatic update ``                   |
| [`47b74dec`](https://github.com/nix-community/NUR/commit/47b74dec0590af547549be4d70d43d8245ef3832) | `` automatic update ``                   |
| [`5eb3bf1a`](https://github.com/nix-community/NUR/commit/5eb3bf1ae6b2e940e0049e27e3632ec4144eb085) | `` automatic update ``                   |
| [`fdc130ab`](https://github.com/nix-community/NUR/commit/fdc130ab85beee841dd929d41e68509fc806c75e) | `` automatic update ``                   |
| [`f2e441ae`](https://github.com/nix-community/NUR/commit/f2e441ae37c6ccc87499dd11f1845178a5eedabf) | `` automatic update ``                   |
| [`d9b574e2`](https://github.com/nix-community/NUR/commit/d9b574e2c55aae5beb07a2c11a699e8a3b5d89bd) | `` automatic update ``                   |
| [`f62fbc8c`](https://github.com/nix-community/NUR/commit/f62fbc8c543df0d728d1c5550e019123dceaf9d4) | `` automatic update ``                   |
| [`2c3f41ac`](https://github.com/nix-community/NUR/commit/2c3f41acd6644a5994b345992bbc23332cdff464) | `` automatic update ``                   |
| [`01936ee3`](https://github.com/nix-community/NUR/commit/01936ee33cef1675ba8475d11aba559d52629d86) | `` automatic update ``                   |
| [`cb380a0e`](https://github.com/nix-community/NUR/commit/cb380a0e70936e4b98281e54636282a5f393aab7) | `` automatic update ``                   |
| [`eeb8fce4`](https://github.com/nix-community/NUR/commit/eeb8fce4d316d67fc9baf0169e626f9cb590c4b7) | `` automatic update ``                   |
| [`622fa891`](https://github.com/nix-community/NUR/commit/622fa8916ebe8f2dfc95f4bfb92ada3cf242a0c8) | `` automatic update ``                   |
| [`766d28a5`](https://github.com/nix-community/NUR/commit/766d28a5c81b7d1b79775a1cfe145fdae71ca749) | `` automatic update ``                   |
| [`44e994db`](https://github.com/nix-community/NUR/commit/44e994dbb3a1757dc299140036ff413139f873ab) | `` automatic update ``                   |
| [`135b21b9`](https://github.com/nix-community/NUR/commit/135b21b92e6aa426bdbb8a3258d2b90d5d9b63d6) | `` automatic update ``                   |
| [`cdb9c820`](https://github.com/nix-community/NUR/commit/cdb9c820416ee3da8a067554f049a620665b1e92) | `` automatic update ``                   |
| [`41d6ff36`](https://github.com/nix-community/NUR/commit/41d6ff3664f2ecae7133590f85649b80bab7f69a) | `` automatic update ``                   |
| [`02b5231a`](https://github.com/nix-community/NUR/commit/02b5231a1393b4b307fa7d3b1df715c0ae7db206) | `` automatic update ``                   |
| [`114eefa4`](https://github.com/nix-community/NUR/commit/114eefa435d57487295dd2f0b5d0f805c4175daa) | `` automatic update ``                   |
| [`4a856683`](https://github.com/nix-community/NUR/commit/4a856683d63a06c7cb8e2dfe857fa14321a42097) | `` automatic update ``                   |
| [`800c7204`](https://github.com/nix-community/NUR/commit/800c72044f2e46616f6469367d5f4f2ddc2cd6b9) | `` automatic update ``                   |
| [`303c85ec`](https://github.com/nix-community/NUR/commit/303c85ec52600a834bdad8fe193338fa9f235034) | `` automatic update ``                   |
| [`cc94476a`](https://github.com/nix-community/NUR/commit/cc94476ab2c6e820a8e242a49a1234f75b28a149) | `` automatic update ``                   |
| [`1a593a9e`](https://github.com/nix-community/NUR/commit/1a593a9e40e55d901bc1e58972dcccc0c3b17807) | `` automatic update ``                   |
| [`9470c4af`](https://github.com/nix-community/NUR/commit/9470c4af62176fe1d31c8a0f7355f129eff3759c) | `` automatic update ``                   |
| [`c48c1214`](https://github.com/nix-community/NUR/commit/c48c12141ff9eba3deacaebecdc515f97b62666d) | `` automatic update ``                   |
| [`3849eeba`](https://github.com/nix-community/NUR/commit/3849eeba5a485d033ab22351a20af24a22a7ebf7) | `` automatic update ``                   |
| [`f00dbebf`](https://github.com/nix-community/NUR/commit/f00dbebfb2e53e06e48f2c09da5eb80dde7d98ae) | `` automatic update ``                   |
| [`9491e71b`](https://github.com/nix-community/NUR/commit/9491e71b09e8886fc9a6380f57d3adcbcc208413) | `` automatic update ``                   |