### PR TITLE
chore(flake/hyprland): `6cf193e1` -> `d679d200`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1730072482,
-        "narHash": "sha256-rCG6d/ZhaETHij+umtwtRu0mvLniQpgO8xG80aoOtac=",
+        "lastModified": 1730143527,
+        "narHash": "sha256-oAHpNAIa6EKt3uTIxCbIbEsuPdvE8en1iIXlgLHDbps=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "6cf193e1662f6f750e964a3e174ae017246b4d48",
+        "rev": "d679d200299ed4670f0d0f138c793d5f507b7cec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`d679d200`](https://github.com/hyprwm/Hyprland/commit/d679d200299ed4670f0d0f138c793d5f507b7cec) | `` seat: avoid sending pointless 'keymap' and 'repeat_info' events (#8276) `` |
| [`7188ee4f`](https://github.com/hyprwm/Hyprland/commit/7188ee4f992966c5793efebd6dc70ab377820066) | `` hyprctl: move setprop into dispatchers (#8275) ``                          |
| [`c7315617`](https://github.com/hyprwm/Hyprland/commit/c7315617eb6186912d03232e1968f32b88f153f2) | `` internal: few more marginal optimisations from profiling (#8271) ``        |
| [`d49a1334`](https://github.com/hyprwm/Hyprland/commit/d49a1334a8af7c704626cdf1746cb72415ad6d0d) | `` swallow: check if swallow_regex doesn't exist (#8265) ``                   |
| [`2c481202`](https://github.com/hyprwm/Hyprland/commit/2c481202effe707451608e272b5a801f8c970052) | `` layout: slight adjustments to snapping logic (#8273) ``                    |