### PR TITLE
chore(flake/spicetify-nix): `1c482c8b` -> `defcdbfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -670,11 +670,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730261837,
-        "narHash": "sha256-syeN2dLFxJ9bhsG1YnwWpwMgCttBY1S60KUrqLIrmMo=",
+        "lastModified": 1730434620,
+        "narHash": "sha256-TRMTZ9nAU31tGTPQpf4ylUYDW+JfpYFbBQrZYf1/xj4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "1c482c8baffd494119b7f61735d35c62a0a22244",
+        "rev": "defcdbfdf0890df65685e25e8920d68035cb7720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`defcdbfd`](https://github.com/Gerg-L/spicetify-nix/commit/defcdbfdf0890df65685e25e8920d68035cb7720) | `` CI update 2024-11-01 `` |
| [`22d250d6`](https://github.com/Gerg-L/spicetify-nix/commit/22d250d6a4dcc492a2d8836d3f2c901a09e7cb76) | `` CI update 2024-10-31 `` |