### PR TITLE
chore(flake/nixpkgs): `18536bf0` -> `807e9154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,10 +23,22 @@
     },
     "aquamarine": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1729527199,
@@ -59,7 +71,10 @@
     },
     "darwin": {
       "inputs": {
-        "nixpkgs": ["agenix", "nixpkgs"]
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1700795494,
@@ -79,7 +94,9 @@
     "firefox-addons": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
@@ -214,7 +231,11 @@
     },
     "gitignore": {
       "inputs": {
-        "nixpkgs": ["hyprland", "pre-commit-hooks", "nixpkgs"]
+        "nixpkgs": [
+          "hyprland",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1709087332,
@@ -232,7 +253,10 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": ["agenix", "nixpkgs"]
+        "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1703113217,
@@ -250,7 +274,9 @@
     },
     "home-manager_2": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1730016908,
@@ -268,9 +294,18 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": ["hyprland", "hyprlang"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728669738,
@@ -315,8 +350,14 @@
     },
     "hyprland-protocols": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728345020,
@@ -334,9 +375,18 @@
     },
     "hyprlang": {
       "inputs": {
-        "hyprutils": ["hyprland", "hyprutils"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728168612,
@@ -354,8 +404,14 @@
     },
     "hyprutils": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728941256,
@@ -373,8 +429,14 @@
     },
     "hyprwayland-scanner": {
       "inputs": {
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1726874836,
@@ -392,7 +454,9 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1729999765,
@@ -514,11 +578,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1729880355,
-        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
@@ -563,7 +627,10 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": ["hyprland", "nixpkgs"],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -598,7 +665,9 @@
     "spicetify-nix": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1730261837,
@@ -676,12 +745,30 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": ["hyprland", "hyprland-protocols"],
-        "hyprlang": ["hyprland", "hyprlang"],
-        "hyprutils": ["hyprland", "hyprutils"],
-        "hyprwayland-scanner": ["hyprland", "hyprwayland-scanner"],
-        "nixpkgs": ["hyprland", "nixpkgs"],
-        "systems": ["hyprland", "systems"]
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1728166987,


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`247954f6`](https://github.com/NixOS/nixpkgs/commit/247954f63780a64378cb231c763c6780b52f4142) | `` wasmtime: 25.0.2 -> 26.0.0 (#350506) ``                                   |
| [`2133ad0d`](https://github.com/NixOS/nixpkgs/commit/2133ad0d84a20ea7fe1f1e6919fe5b9eeb47613d) | `` clightning: 24.08.1 -> 24.08.2 ``                                         |
| [`1873bf42`](https://github.com/NixOS/nixpkgs/commit/1873bf425448b4b9f3ce45eb26598db4e6618cb0) | `` daed: fix `pnpm.fetchDeps` hash ``                                        |
| [`bc150202`](https://github.com/NixOS/nixpkgs/commit/bc150202e2ac77af6bcb8fac7e29d31058f2984b) | `` python312Packages.packageurl-python: 0.15.6 -> 0.16.0 ``                  |
| [`7cf50843`](https://github.com/NixOS/nixpkgs/commit/7cf50843e1ba7be4fa52664921f1185fe1d91139) | `` libpkgconf: Update meta.homepage (#351976) ``                             |
| [`2dbd1f96`](https://github.com/NixOS/nixpkgs/commit/2dbd1f96f22fccbc47851e6584a25159b73e14f7) | `` mmdbctl: init at 1.4.6 ``                                                 |
| [`0c5f2e03`](https://github.com/NixOS/nixpkgs/commit/0c5f2e03731f61f76e9ca528c50bff1bea4240ea) | `` objfw: use clang stdenv ``                                                |
| [`98d77d14`](https://github.com/NixOS/nixpkgs/commit/98d77d1446838762c6444cdc80ecc917dcb521ed) | `` uv: 0.4.26 → 0.4.28 ``                                                    |
| [`355e12b6`](https://github.com/NixOS/nixpkgs/commit/355e12b665339290efd7d08180d423973d70228f) | `` x4: init at 0.1.0 (#346736) ``                                            |
| [`9f128a2f`](https://github.com/NixOS/nixpkgs/commit/9f128a2fb269a39f4dee4eb3c108be3a25768204) | `` coqPackages.mathcomp-reals: init at 1.7.0 ``                              |
| [`da26ed26`](https://github.com/NixOS/nixpkgs/commit/da26ed26f00f6b7525b21a20ece706b34acb4427) | `` klog-rs: init at 0.0.3 ``                                                 |
| [`47bbe19a`](https://github.com/NixOS/nixpkgs/commit/47bbe19a670acf50f29df25157dc4cc5d8517815) | `` terraform-providers.opentelekomcloud: 1.36.20 -> 1.36.23 ``               |
| [`1d386e00`](https://github.com/NixOS/nixpkgs/commit/1d386e00279a92756a1a3bc4e29a1bc6391ca97b) | `` phpPackages.php-cs-fixer: 3.58.1 -> 3.64.0 ``                             |
| [`c0dfdd22`](https://github.com/NixOS/nixpkgs/commit/c0dfdd22db95bdbb363055459ccb139613389bda) | `` pkgs/README: fix reference to deleted GMP version ``                      |
| [`b0f417b5`](https://github.com/NixOS/nixpkgs/commit/b0f417b5e9df79953ea12f1c15e7e2fd8d3b3c19) | `` kdePackages.drkonqi: fix undetected dependency on gdb ``                  |
| [`01ac3acf`](https://github.com/NixOS/nixpkgs/commit/01ac3acfc7a056e5da5d7f0dbfb7b84f43702a63) | `` phpPackages.phing: 3.0.0-rc6 -> 3.0.0 ``                                  |
| [`4eff0560`](https://github.com/NixOS/nixpkgs/commit/4eff05607ceee9ffafd9f9d22d84db619a7bd95c) | `` ivyterm: init at unstable-2024-10-23 ``                                   |
| [`79dd55af`](https://github.com/NixOS/nixpkgs/commit/79dd55af660fc815dad965ffd8a7bde865b259c5) | `` dmenu-rs: refactor to add variant with enabled plugins ``                 |
| [`329a9c1d`](https://github.com/NixOS/nixpkgs/commit/329a9c1d97f0b697bf617dc2e8d3f19f83f305f1) | `` dmenu-rs: move to pkgs/by-name ``                                         |
| [`5655804f`](https://github.com/NixOS/nixpkgs/commit/5655804f06d728a49c1120f9c1a9ed0ecee41c85) | `` polybar-pulseaudio-control: add missing runtime dependencies (#352006) `` |
| [`608f6021`](https://github.com/NixOS/nixpkgs/commit/608f60217d12a06ca891f859308805ecc42cf4fc) | `` python312Packages.psd-tools: 1.10.0 -> 1.10.2 ``                          |
| [`d89e5699`](https://github.com/NixOS/nixpkgs/commit/d89e56994aa9d6834ef86797094c8f9c92500ca2) | `` python312Packages.open-clip-torch: 2.28.0 -> 2.29.0 ``                    |
| [`26eb0594`](https://github.com/NixOS/nixpkgs/commit/26eb0594ce79e2d86c2503dbff6a481f6fe16612) | `` python312Packages.libretranslate: 1.6.1 -> 1.6.2 ``                       |
| [`2ddbe069`](https://github.com/NixOS/nixpkgs/commit/2ddbe069a5c8ee0a5640593d4ed5466264664c0f) | `` immich-machine-learning: inherit license and maintainers from immich ``   |
| [`3c406f13`](https://github.com/NixOS/nixpkgs/commit/3c406f13b5219c6ecb7c177176101e0780e8005e) | `` newlisp: init at 10.7.5 ``                                                |
| [`452e3844`](https://github.com/NixOS/nixpkgs/commit/452e3844ee1478a6a69dfc60dc23cac4be760c16) | `` go2rtc: 1.9.4 -> 1.9.5 (#352016) ``                                       |
| [`6b2f5da3`](https://github.com/NixOS/nixpkgs/commit/6b2f5da38cc85b46d0f33e24cbc3cfe5565864dc) | `` python312Packages.drf-writable-nested: 0.7.0 -> 0.7.1 ``                  |
| [`cd987029`](https://github.com/NixOS/nixpkgs/commit/cd987029e71ebe40d799fbf4e0f29b611919cba0) | `` maintainers: add rc-zb ``                                                 |
| [`65323240`](https://github.com/NixOS/nixpkgs/commit/65323240d0fdfdcfef70f44988d999de858d97d3) | `` disko: 1.8.2 -> 1.9.0 ``                                                  |
| [`e498e292`](https://github.com/NixOS/nixpkgs/commit/e498e2921e9b2e29724438382dd51764a5818320) | `` kor: 0.5.5 -> 0.5.6 ``                                                    |
| [`30c9efee`](https://github.com/NixOS/nixpkgs/commit/30c9efeef01e2ad4880bff6a01a61dd99536b3c9) | `` smlnj: 110.95 -> 110.99.6.1 ``                                            |
| [`e7b4ab5f`](https://github.com/NixOS/nixpkgs/commit/e7b4ab5f1188b89fc2f02bbd1ef8cc74973778cf) | `` ssldump: 1.7 -> 1.8-unstable-2024-10-16 ``                                |
| [`dadf2efe`](https://github.com/NixOS/nixpkgs/commit/dadf2efe1d381162d258357af499bd2b8722c0cc) | `` maintainers: update frontear's fingerprint ``                             |
| [`3d7309ed`](https://github.com/NixOS/nixpkgs/commit/3d7309ed17291897a704f2be3229605fcada446c) | `` opengfw: 0.4.0 -> 0.4.1 ``                                                |
| [`705b5b99`](https://github.com/NixOS/nixpkgs/commit/705b5b9987e2f1afd3bb0f0044b1f22d4106c0c7) | `` python312Packages.bytecode: 0.15.1 -> 0.16.0 ``                           |
| [`69a8315b`](https://github.com/NixOS/nixpkgs/commit/69a8315b19eaa974a97654f788a318f1c19d0fcf) | `` python312Packages.diffenator2: 0.4.4 -> 0.4.5 ``                          |
| [`6e267d9c`](https://github.com/NixOS/nixpkgs/commit/6e267d9ce476cb7e65517bd76bbeeac78a0d3658) | `` kotatogram-desktop: 0-unstable-2024-09-27 -> 1.4.9-unstable-2024-09-27 `` |
| [`5b762a44`](https://github.com/NixOS/nixpkgs/commit/5b762a443b2cfb388a230651caf8adf3c231fc5e) | `` kotatogram-desktop: fix build on Darwin ``                                |
| [`9da08bd6`](https://github.com/NixOS/nixpkgs/commit/9da08bd6b94cee6d773c6035a73290cde359b060) | `` terraform-providers.huaweicloud: 1.69.0 -> 1.69.1 ``                      |
| [`bcccdece`](https://github.com/NixOS/nixpkgs/commit/bcccdece675ba29d8833e714e13696b5fa44595c) | `` terraform-providers.sentry: 0.13.1 -> 0.14.0 ``                           |
| [`0e8d672d`](https://github.com/NixOS/nixpkgs/commit/0e8d672d896cb23cbe1a2bfaa2cce47199b3ab6b) | `` seq66: 0.99.14 -> 0.99.15 ``                                              |
| [`c92e591b`](https://github.com/NixOS/nixpkgs/commit/c92e591bdad23b72929c6f81f795e59447e04cf7) | `` skeditor: init at 2.8.1 ``                                                |
| [`45e345bd`](https://github.com/NixOS/nixpkgs/commit/45e345bdcfcadd64f56285e4992f4fbcf34eb499) | `` Revert "python312Packages.django-otp-webauthn: 0.3.0 -> 0.4.0" ``         |
| [`74e0f237`](https://github.com/NixOS/nixpkgs/commit/74e0f237ea3fa5877560a376fef5e07d1917027b) | `` immich: 1.118.2 -> 1.119.0 ``                                             |
| [`90f6f1d6`](https://github.com/NixOS/nixpkgs/commit/90f6f1d6ae6dd818c9fd70e51154e64fcebb2cc2) | `` immich: use jellyfin-ffmpeg ``                                            |
| [`98e6484f`](https://github.com/NixOS/nixpkgs/commit/98e6484f9b307db7762c5be24bfa3a7a26e479c5) | `` python312Packages.py-opensonic: 5.1.1 -> 5.2.0 ``                         |
| [`4d3da079`](https://github.com/NixOS/nixpkgs/commit/4d3da07901b6272a59c4016b9b0ca577f349a302) | `` vimPlugins.lze: 0.1.3 -> 0.1.4 ``                                         |
| [`bea1e3dc`](https://github.com/NixOS/nixpkgs/commit/bea1e3dc44ab288ea3f309d2ec5a00d92f36d76d) | `` gns3-server: 2.2.49 -> 2.2.50 ``                                          |
| [`0dacc47b`](https://github.com/NixOS/nixpkgs/commit/0dacc47bfc0b3b713fec925d5bb52e63adfc91dc) | `` gns3-gui: 2.2.49 -> 2.2.50 ``                                             |
| [`32d516c8`](https://github.com/NixOS/nixpkgs/commit/32d516c84d8a1bd6ef64b8e836ca70f01d410efc) | `` nixos/radicale: fix links to documentation ``                             |
| [`58cddcde`](https://github.com/NixOS/nixpkgs/commit/58cddcdefe66c8fcb74ce3a5a4edf1c056a89bc9) | `` octodns: 1.9.1 -> 1.10.0 ``                                               |
| [`df594537`](https://github.com/NixOS/nixpkgs/commit/df594537aeccddf735b56c85f1de523dd5732f44) | `` zabbix-cli: 3.1.2 -> 3.1.3 ``                                             |
| [`c7c2073d`](https://github.com/NixOS/nixpkgs/commit/c7c2073d84639ffa8c453dfcde080fe3983d9e25) | `` steampipePackages.steampipe-plugin-github: use correct license ``         |
| [`1aa7f056`](https://github.com/NixOS/nixpkgs/commit/1aa7f056edd025a1e4ae4972eb176020fd65d502) | `` steampipePackages.steampipe-plugin-aws: use correct license ``            |
| [`16811668`](https://github.com/NixOS/nixpkgs/commit/168116687e6560772f6d33facd208149b70f5355) | `` drone-scp: 1.6.14 -> 1.7.0 ``                                             |
| [`bb7ad9ba`](https://github.com/NixOS/nixpkgs/commit/bb7ad9ba287c0aef93a4332f135d7bfd0341489f) | `` gitleaks: 8.21.0 -> 8.21.2 ``                                             |
| [`1e5e9ac9`](https://github.com/NixOS/nixpkgs/commit/1e5e9ac9a93d3630efcc58a21ab2767cc2d248a3) | `` vimPlugins.nvim-treesitter: update grammars ``                            |
| [`d396643b`](https://github.com/NixOS/nixpkgs/commit/d396643b2950b47f3ecaed171ebaf0a952edd288) | `` vimPlugins: update on 2024-10-28 ``                                       |
| [`68b122d2`](https://github.com/NixOS/nixpkgs/commit/68b122d2f6e39e5c53510529c5acd0c7bc52dd8b) | `` nixos/nezha-agent: add extraFlags ``                                      |
| [`4c6a66b8`](https://github.com/NixOS/nixpkgs/commit/4c6a66b84edacd4e3ca2894f24555edf9f34455e) | `` nezha-agent: 0.20.2 -> 0.20.3 ``                                          |
| [`0e158f7f`](https://github.com/NixOS/nixpkgs/commit/0e158f7f9d9807cd303a050d986a2f5554b7c7b5) | `` forgejo-lts: 7.0.9 -> 7.0.10 ``                                           |
| [`5791ef1d`](https://github.com/NixOS/nixpkgs/commit/5791ef1dbaaae0c0107f2b86503993bd308a76d3) | `` luaPackages: update on 2024-10-28 ``                                      |
| [`c42882fc`](https://github.com/NixOS/nixpkgs/commit/c42882fcb225835aef6a58a71c3a59bc8029697d) | `` scx: init at 1.05 ``                                                      |
| [`02c5d85b`](https://github.com/NixOS/nixpkgs/commit/02c5d85bb2b2a5e4971ea56ac54f97ca49056dd3) | `` python312Packages.airthings-ble: 0.9.1 -> 0.9.2 ``                        |
| [`6738a38c`](https://github.com/NixOS/nixpkgs/commit/6738a38cf53e2fed4461063c3da5bb5f96c3f5a5) | `` forgejo: 9.0.0 -> 9.0.1 ``                                                |
| [`e706c319`](https://github.com/NixOS/nixpkgs/commit/e706c319423570adfec95ec944a37dfb6ea59d82) | `` audiobookshelf: 2.15.1 -> 2.16.0 ``                                       |
| [`905d7cf7`](https://github.com/NixOS/nixpkgs/commit/905d7cf77ebdccd01480fad483ad0eaed5ab3889) | `` pretalx: disable racy test ``                                             |
| [`feca8a8a`](https://github.com/NixOS/nixpkgs/commit/feca8a8a56d13f290856275d6eb6ce420ddbd05a) | `` cppcheck: 2.15.0 -> 2.16.0 ``                                             |
| [`cc61a44b`](https://github.com/NixOS/nixpkgs/commit/cc61a44bf9aa918b6ae86735396f6193963648b2) | `` python3.pkgs.pylsl: init at 1.16.2 ``                                     |
| [`4832a5ae`](https://github.com/NixOS/nixpkgs/commit/4832a5aee2b68bc0553069b1817478131b1e3566) | `` maintainers: add abcsds ``                                                |
| [`5ba0dd20`](https://github.com/NixOS/nixpkgs/commit/5ba0dd20427a4dfd6264362f13ec5bce75fe67f5) | `` liblsl: init at 1.16.2 ``                                                 |
| [`800ffc56`](https://github.com/NixOS/nixpkgs/commit/800ffc56a2db95c9fb24c4a75be9803e9f8d8465) | `` fooyin: 0.7.2 -> 0.8.1 ``                                                 |
| [`2125b7ca`](https://github.com/NixOS/nixpkgs/commit/2125b7cadc325915c4a685bd51ad187a2c945460) | `` python3Packages.ifcopenshell: 0.7.0 -> 0.8.0 (#347916) ``                 |
| [`e7d27dc0`](https://github.com/NixOS/nixpkgs/commit/e7d27dc05401dd8348226c1dac462e96114102f5) | `` bark-server: init at 2.1.5 ``                                             |
| [`d71b7859`](https://github.com/NixOS/nixpkgs/commit/d71b785970139c2065532ae8e6e921f555be3a17) | `` paratest: 7.4.3 -> 7.6.0 ``                                               |
| [`54bbc58c`](https://github.com/NixOS/nixpkgs/commit/54bbc58c29bb1957acddf5c7b07beeb4234a51b0) | `` fido2-manage: init at 0-unstable-2024-09-24 (#347516) ``                  |