### PR TITLE
chore(flake/home-manager): `e8341405` -> `1743615b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730016908,
-        "narHash": "sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0=",
+        "lastModified": 1730490306,
+        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e83414058edd339148dc142a8437edb9450574c8",
+        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`1743615b`](https://github.com/nix-community/home-manager/commit/1743615b61c7285976f85b303a36cdf88a556503) | `` podman: add module ``                                    |
| [`8ca921e5`](https://github.com/nix-community/home-manager/commit/8ca921e5a806b5b6171add542defe7bdac79d189) | `` git-credential-oauth: fix ordering of git extraConfig `` |