### PR TITLE
chore(flake/nur): `761c6a7d` -> `187f8309`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1730411166,
-        "narHash": "sha256-o1JcjEnWhnxkkKXYN1gQeO53RUsQExFsgMOJ/FzuFX0=",
+        "lastModified": 1730505809,
+        "narHash": "sha256-MObxP7NSU0WnjlNX2nWvfO+7AlOHSQq0nbsQ5jgHtMA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "761c6a7d6859126681d206126ba26ec58306d068",
+        "rev": "187f8309facb4c1e05dc068dea2e10c38e8f6b4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`187f8309`](https://github.com/nix-community/NUR/commit/187f8309facb4c1e05dc068dea2e10c38e8f6b4b) | `` automatic update `` |
| [`b880c8c3`](https://github.com/nix-community/NUR/commit/b880c8c347dd996bd7d4e9e139e15ee210e236cd) | `` automatic update `` |
| [`3d720530`](https://github.com/nix-community/NUR/commit/3d720530c32273537ef723a8b5f72c0ecdd1ad2e) | `` automatic update `` |
| [`a7b165eb`](https://github.com/nix-community/NUR/commit/a7b165eb4058b48dc60ca727a2c0cbba4236b8dd) | `` automatic update `` |
| [`6a83c1ed`](https://github.com/nix-community/NUR/commit/6a83c1ed729e1c43cee5bd7ba0fa2f4ea185fb4c) | `` automatic update `` |
| [`55bbf103`](https://github.com/nix-community/NUR/commit/55bbf1030eedddf2de39c0005e12266ef5dc6c41) | `` automatic update `` |
| [`2cbae9ac`](https://github.com/nix-community/NUR/commit/2cbae9ac97e9b41e3f83f0d3e118306ae1a8fd50) | `` automatic update `` |
| [`334c084b`](https://github.com/nix-community/NUR/commit/334c084b8cec0ed0323e8d7d1a81d6bfb2824974) | `` automatic update `` |
| [`2e0f8129`](https://github.com/nix-community/NUR/commit/2e0f81298ba56aa8d615b8c594e1ae77baad744a) | `` automatic update `` |
| [`52c21ec8`](https://github.com/nix-community/NUR/commit/52c21ec8fde46366b1a5555e18d854ee18012ac8) | `` automatic update `` |
| [`0cec4b96`](https://github.com/nix-community/NUR/commit/0cec4b96fa9a9f3b348439ede1fd5ef46593b966) | `` automatic update `` |
| [`d549bc24`](https://github.com/nix-community/NUR/commit/d549bc24e18325d857d8e39a237e6a4caa5cd030) | `` automatic update `` |
| [`f58aaf65`](https://github.com/nix-community/NUR/commit/f58aaf6579697a5bd3d861cbc93a735f50e667a1) | `` automatic update `` |
| [`5bf60345`](https://github.com/nix-community/NUR/commit/5bf603459b923edbee4955e9fc94b94662add85c) | `` automatic update `` |
| [`6245edb4`](https://github.com/nix-community/NUR/commit/6245edb4d3799103b1a3805b90ca9a9818c5ad1e) | `` automatic update `` |
| [`7f3bc4c9`](https://github.com/nix-community/NUR/commit/7f3bc4c98c7df7d2e13ec03f0a04d38a2214ef6d) | `` automatic update `` |
| [`f4a66e55`](https://github.com/nix-community/NUR/commit/f4a66e555ee802d3d6ac0a0c1d4e86909ce59639) | `` automatic update `` |
| [`1c95a109`](https://github.com/nix-community/NUR/commit/1c95a10940bc0ce0d6b28dd092a3d6a1c45555cb) | `` automatic update `` |
| [`fdd43a02`](https://github.com/nix-community/NUR/commit/fdd43a02d87ed541931e1998748e08b7983a1258) | `` automatic update `` |
| [`cb8768d8`](https://github.com/nix-community/NUR/commit/cb8768d8e2dc59c5c56c69c80707c5ac7c61d1a9) | `` automatic update `` |
| [`08dc863f`](https://github.com/nix-community/NUR/commit/08dc863ff0cf318a95eda28e97ae8ec032b28526) | `` automatic update `` |
| [`442d589e`](https://github.com/nix-community/NUR/commit/442d589ed82d76d05292e1882460636582b58c26) | `` automatic update `` |
| [`8e7d8d3e`](https://github.com/nix-community/NUR/commit/8e7d8d3e33c2c2666820e9ff32d1dae6ebcc2ebd) | `` automatic update `` |
| [`0e23e731`](https://github.com/nix-community/NUR/commit/0e23e731ded050d563fd4a55b1e29a572e0522ab) | `` automatic update `` |
| [`5ef5f243`](https://github.com/nix-community/NUR/commit/5ef5f243936bc6387b55fc8cb08c88e7cf68092a) | `` automatic update `` |
| [`3ac24393`](https://github.com/nix-community/NUR/commit/3ac243930a3ff3c8f118c4736c50a98799ee4913) | `` automatic update `` |
| [`bba76a25`](https://github.com/nix-community/NUR/commit/bba76a2537db268ba05861aa251d7263ea560259) | `` automatic update `` |
| [`318a4f95`](https://github.com/nix-community/NUR/commit/318a4f9563ab587ab9c888eb5069077a642d2276) | `` automatic update `` |
| [`e3538cad`](https://github.com/nix-community/NUR/commit/e3538cadd822131ba19c701a851afc1f77877de5) | `` automatic update `` |
| [`a23167e8`](https://github.com/nix-community/NUR/commit/a23167e87c157228bb9110ddc7249b2a50b6af47) | `` automatic update `` |