### PR TITLE
chore(flake/nix-vscode-extensions): `bdda106f` -> `96dcbddd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -479,11 +479,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1730339415,
-        "narHash": "sha256-3dbUPDSAteNUvaMh3mh61FBQNhhT9n3XBQH2HK0C8+I=",
+        "lastModified": 1730426202,
+        "narHash": "sha256-swwKpE3lrdvcSh6Hjyf/eSe/zPnsZgeVlSl+B4yBpeo=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "bdda106fe8c2beda62338254783c562bfb5648a2",
+        "rev": "96dcbddd24edc60ad47f41bb2a73e06099eba4af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                               | Message      |
| -------------------------------------------------------------------------------------------------------------------- | ------------ |
| [`96dcbddd`](https://github.com/nix-community/nix-vscode-extensions/commit/96dcbddd24edc60ad47f41bb2a73e06099eba4af) | `` action `` |