### PR TITLE
chore(flake/hyprland): `93b4478e` -> `32b18179`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1730373668,
-        "narHash": "sha256-UNBRvBacwYSFmM5TvWx4ASGMWs42tGP0AhUW/adWE/k=",
+        "lastModified": 1730499652,
+        "narHash": "sha256-R21C3/2eI5hlwfUSkXFFX/8Wbs3lm43jVYrxd+9SPfM=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "93b4478e70af6ffb08a4a66a6d0364c3296db296",
+        "rev": "32b18179dd789cde948c97eb3c2ebbdd6af36bf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`32b18179`](https://github.com/hyprwm/Hyprland/commit/32b18179dd789cde948c97eb3c2ebbdd6af36bf7) | `` CMake: systemd fixes ``                                   |
| [`29e7dc64`](https://github.com/hyprwm/Hyprland/commit/29e7dc642831801d14480cf7e4bb19f6ffb118e9) | `` Systemd fixes ``                                          |
| [`3c0605c6`](https://github.com/hyprwm/Hyprland/commit/3c0605c68e50416819fea471a8fbef05e4a18684) | `` hyprland-systemd.desktop improvements (#8318) ``          |
| [`d8b86536`](https://github.com/hyprwm/Hyprland/commit/d8b865366af9d5ed30d2ee0a437b9a3ed43c10bd) | `` renderer: Add a missing texture asset and a user check `` |
| [`3852418d`](https://github.com/hyprwm/Hyprland/commit/3852418d2446555509738bf1486940042107afe7) | `` hyprctl: reload windowrules on reloadAll ``               |
| [`c4d214c4`](https://github.com/hyprwm/Hyprland/commit/c4d214c42d743a69f606ff476b7266b3ace7d70e) | `` monitors: fix vrr breaking monitor disconnect (#8314) ``  |