### PR TITLE
chore(flake/home-manager): `a9953635` -> `fc52a210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735291276,
-        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1733940404,
-        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734906446,
-        "narHash": "sha256-6OWluVE2A8xi+8V3jN9KA72RCgJjYdyyuLBUjxZ2q2U=",
+        "lastModified": 1736102453,
+        "narHash": "sha256-5qb4kb7Xbt8jJFL/oDqOor9Z2+E+A+ql3PiyDvsfWZ0=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "eecb74dc79bb6752a2a507e6edee3042390a6091",
+        "rev": "4846091641f3be0ad7542086d52769bb7932bde6",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734906236,
-        "narHash": "sha256-vH/ysV2ONGQgYZPtcJKwc8jJivzyVxru2aaOxC20ZOE=",
+        "lastModified": 1736115290,
+        "narHash": "sha256-Jcn6yAzfUMcxy3tN/iZRbi/QgrYm7XLyVRl9g/nbUl4=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "6dea3fba08fd704dd624b6d4b261638fb4003c9c",
+        "rev": "52202272d89da32a9f866c0d10305a5e3d954c50",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1735585949,
-        "narHash": "sha256-0nT9kNyyQlhpMHakQLyINZoJAjRAui4WsbxrRev6Gwc=",
+        "lastModified": 1736279929,
+        "narHash": "sha256-F7e1z0rbCmvDLhbBuQ6Y/zzFYRBZXuSP1GrsterrdwU=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "1989b0049f7fb714a2417dfb14d6b4f3d2a079d3",
+        "rev": "67e1e46f9b6285ea260bc88844f85dec6b7d7d02",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728345020,
-        "narHash": "sha256-xGbkc7U/Roe0/Cv3iKlzijIaFBNguasI31ynL2IlEoM=",
+        "lastModified": 1735774328,
+        "narHash": "sha256-vIRwLS9w+N99EU1aJ+XNOU6mJTxrUBa31i1r82l0V7s=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "a7c183800e74f337753de186522b9017a07a8cee",
+        "rev": "e3b6af97ddcfaafbda8e2828c719a5af84f662cb",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734906472,
-        "narHash": "sha256-pWPRv/GA/X/iAwoE6gMNUqn/ZeJX1IeLPRpZI0tTPK0=",
+        "lastModified": 1736114838,
+        "narHash": "sha256-FxbuGQExtN37ToWYnGmO6weOYN6WPHN/RAqbr7gNPek=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "c77109d7e1ddbcdb87cafd32ce411f76328ae152",
+        "rev": "6997fe382dcf396704227d2b98ffdd5066da6959",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734906259,
-        "narHash": "sha256-P79t/7HbACO4/PuJBroGpTptvCWJtXTv+gWsF+sM6MI=",
+        "lastModified": 1735393019,
+        "narHash": "sha256-NPpqA8rtmDLsEmZOmz+qR67zsB6Y503Jnv+nSFLKJZ8=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "0404833ea18d543df44df935ebf1b497310eb046",
+        "rev": "55608efdaa387af7bfdc0eddb404c409958efa43",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735316583,
-        "narHash": "sha256-AiiUwHWHfEdpFzXy7l1x3zInCUa1xcRMrbZ1XRSkzwU=",
+        "lastModified": 1736164519,
+        "narHash": "sha256-1LimBKvDpBbeX+qW7T240WEyw+DBVpDotZB4JYm8Aps=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "8f15d45b120b33712f6db477fe5ffb18034d0ea8",
+        "rev": "3c895da64b0eb19870142196fa48c07090b441c4",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734793513,
-        "narHash": "sha256-rrrHcXapXJvGFqX+L/Bb0182L25jofAZ0fm1FInvrTQ=",
+        "lastModified": 1735493474,
+        "narHash": "sha256-fktzv4NaqKm94VAkAoVqO/nqQlw+X0/tJJNAeCSfzK4=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "4d7367b6eee87397e2dbca2e78078dd0a4ef4c61",
+        "rev": "de913476b59ee88685fdc018e77b8f6637a2ae0b",
         "type": "github"
       },
       "original": {
@@ -588,29 +588,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1735291276,
-        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {
@@ -690,15 +674,14 @@
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1734797603,
-        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731774881,
-        "narHash": "sha256-1Dxryiw8u2ejntxrrv3sMtIE8WHKxmlN4KeH+uMGbmc=",
+        "lastModified": 1731959031,
+        "narHash": "sha256-TGcvIjftziC1CjuiHCzrYDwmOoSFYIhdiKmLetzB5L0=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "b31a6a4da8199ae3489057db7d36069a70749a56",
+        "rev": "4468981c1c50999f315baa1508f0e53c4ee70c52",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,42 @@
         "type": "github"
       }
     },
+    "hyprgraphics": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733248371,
+        "narHash": "sha256-FFLJzFTyNhS7tBEEECx0B8Ye/bpmxhFVEKlECgMLc6c=",
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "rev": "cc95e5babc6065bc3ab4cd195429a9900836ef13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "type": "github"
+      }
+    },
     "hyprland": {
       "inputs": {
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
+        "hyprgraphics": "hyprgraphics",
         "hyprland-protocols": "hyprland-protocols",
+        "hyprland-qtutils": "hyprland-qtutils",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -335,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1732737540,
-        "narHash": "sha256-ORogf5yeqxar+fMJek+rpUgfnCOYcoeomvczo/tYOcE=",
+        "lastModified": 1734219437,
+        "narHash": "sha256-NVQIAvfSpBSJaJ4BP1cE1yVGjCuvXs0NN1G1t+f52Ss=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5329298b522e3cc1201894909443775b00aeb336",
+        "rev": "db249648776875ce3142141d0d3055e43ce606aa",
         "type": "github"
       },
       "original": {
@@ -370,6 +401,35 @@
       "original": {
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-qtutils": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733472316,
+        "narHash": "sha256-PvXiFLIExJEJj+goLbIuXLTN5CSDSAUsAfiYSdbbWg0=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
+        "rev": "969427419276c7ee170301ef1ebe0f68eb6eb2e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
         "type": "github"
       }
     },
@@ -414,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731702627,
-        "narHash": "sha256-+JeO9gevnXannQxMfR5xzZtF4sYmSlWkX/BPmPx0mWk=",
+        "lastModified": 1732288281,
+        "narHash": "sha256-XTU9B53IjGeJiJ7LstOhuxcRjCOFkQFl01H78sT9Lg4=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e911361a687753bbbdfe3b6a9eab755ecaf1d9e1",
+        "rev": "b26f33cc1c8a7fd5076e19e2cce3f062dca6351c",
         "type": "github"
       },
       "original": {
@@ -546,11 +606,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {
@@ -634,11 +694,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -771,11 +831,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731703417,
-        "narHash": "sha256-rheDc/7C+yI+QspYr9J2z9kQ5P9F4ATapI7qyFAe1XA=",
+        "lastModified": 1733157064,
+        "narHash": "sha256-NetqJHAN4bbZDQADvpep+wXk2AbMZ2bN6tINz8Kpz6M=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "8070f36deec723de71e7557441acb17e478204d3",
+        "rev": "fd85ef39369f95eed67fdf3f025e86916edeea2f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731959031,
-        "narHash": "sha256-TGcvIjftziC1CjuiHCzrYDwmOoSFYIhdiKmLetzB5L0=",
+        "lastModified": 1734400729,
+        "narHash": "sha256-Bf+oya0BuleVXYGIWsb0eWnrK6s0aiesOsI7Mpj1pMU=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "4468981c1c50999f315baa1508f0e53c4ee70c52",
+        "rev": "a132fa41be7ebe797ad758e84d9df068151a723b",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728669738,
-        "narHash": "sha256-EDNAU9AYcx8OupUzbTbWE1d3HYdeG0wO6Msg3iL1muk=",
+        "lastModified": 1734364709,
+        "narHash": "sha256-+2bZJL2u5hva7rSp65OfKJBK+k03T6GB/NCvpoS1OOo=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "0264e698149fcb857a66a53018157b41f8d97bb0",
+        "rev": "f388aacd22be4a6e4d634fbaf6f75eb0713d239a",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733248371,
-        "narHash": "sha256-FFLJzFTyNhS7tBEEECx0B8Ye/bpmxhFVEKlECgMLc6c=",
+        "lastModified": 1733684019,
+        "narHash": "sha256-2kYREgmSmbLsmDpLEq96hxVAU3qz8aCvVhF65yCFZHY=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "cc95e5babc6065bc3ab4cd195429a9900836ef13",
+        "rev": "fb2c0268645a77403af3b8a4ce8fa7ba5917f15d",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1734219437,
-        "narHash": "sha256-NVQIAvfSpBSJaJ4BP1cE1yVGjCuvXs0NN1G1t+f52Ss=",
+        "lastModified": 1734822454,
+        "narHash": "sha256-VhBUmov3V3BoVd8dJXvqjvskIRjJ7f8JadEh3T1WNBw=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "db249648776875ce3142141d0d3055e43ce606aa",
+        "rev": "31422ae25dee33dd000798b64a80bd7fd08d2ece",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733472316,
-        "narHash": "sha256-PvXiFLIExJEJj+goLbIuXLTN5CSDSAUsAfiYSdbbWg0=",
+        "lastModified": 1733940128,
+        "narHash": "sha256-hmfXWj2GA9cj1QUkPFYtAAeohhs615zL4E3APy3FnvQ=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "969427419276c7ee170301ef1ebe0f68eb6eb2e2",
+        "rev": "3833097e50473a152dd614d4b468886840b4ea78",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728168612,
-        "narHash": "sha256-AnB1KfiXINmuiW7BALYrKqcjCnsLZPifhb/7BsfPbns=",
+        "lastModified": 1734364628,
+        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f054f2e44d6a0b74607a6bc0f52dba337a3db38e",
+        "rev": "16e59c1eb13d9fb6de066f54e7555eb5e8a4aba5",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732288281,
-        "narHash": "sha256-XTU9B53IjGeJiJ7LstOhuxcRjCOFkQFl01H78sT9Lg4=",
+        "lastModified": 1734384247,
+        "narHash": "sha256-bl3YyJb2CgaeVKYq/l8j27vKdbkTpDNFDsnCl0dnNlY=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "b26f33cc1c8a7fd5076e19e2cce3f062dca6351c",
+        "rev": "e6cf45cd1845368702e03b8912f4cc44ebba3322",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726874836,
-        "narHash": "sha256-VKR0sf0PSNCB0wPHVKSAn41mCNVCnegWmgkrneKDhHM=",
+        "lastModified": 1734384417,
+        "narHash": "sha256-noYeXcNQ15g1/gIJIYT2zdO66wzY5Z06PYz6BfKUZA8=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "500c81a9e1a76760371049a8d99e008ea77aa59e",
+        "rev": "90e87f7fcfcce4862826d60332cbc5e2f87e1f88",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1734379367,
+        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
         "type": "github"
       },
       "original": {
@@ -831,11 +831,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733157064,
-        "narHash": "sha256-NetqJHAN4bbZDQADvpep+wXk2AbMZ2bN6tINz8Kpz6M=",
+        "lastModified": 1734422917,
+        "narHash": "sha256-0y7DRaXslhfqVKV8a/talYTYAe2NHOQhMZG7KMNRCtc=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "fd85ef39369f95eed67fdf3f025e86916edeea2f",
+        "rev": "3e884d941ca819c1f2e50df8bdae0debded1ed87",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734400729,
-        "narHash": "sha256-Bf+oya0BuleVXYGIWsb0eWnrK6s0aiesOsI7Mpj1pMU=",
+        "lastModified": 1734906446,
+        "narHash": "sha256-6OWluVE2A8xi+8V3jN9KA72RCgJjYdyyuLBUjxZ2q2U=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "a132fa41be7ebe797ad758e84d9df068151a723b",
+        "rev": "eecb74dc79bb6752a2a507e6edee3042390a6091",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364709,
-        "narHash": "sha256-+2bZJL2u5hva7rSp65OfKJBK+k03T6GB/NCvpoS1OOo=",
+        "lastModified": 1734906540,
+        "narHash": "sha256-vQ/L9hZFezC0LquLo4TWXkyniWtYBlFHAKIsDc7PYJE=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "f388aacd22be4a6e4d634fbaf6f75eb0713d239a",
+        "rev": "69270ba8f057d55b0e6c2dca0e165d652856e613",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733684019,
-        "narHash": "sha256-2kYREgmSmbLsmDpLEq96hxVAU3qz8aCvVhF65yCFZHY=",
+        "lastModified": 1734906236,
+        "narHash": "sha256-vH/ysV2ONGQgYZPtcJKwc8jJivzyVxru2aaOxC20ZOE=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "fb2c0268645a77403af3b8a4ce8fa7ba5917f15d",
+        "rev": "6dea3fba08fd704dd624b6d4b261638fb4003c9c",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1734822454,
-        "narHash": "sha256-VhBUmov3V3BoVd8dJXvqjvskIRjJ7f8JadEh3T1WNBw=",
+        "lastModified": 1735394862,
+        "narHash": "sha256-6/4VTVdtg8/DJUy/FsOk+bSoqAeYwZGFnCexmNaPWk0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "31422ae25dee33dd000798b64a80bd7fd08d2ece",
+        "rev": "2b01a5bcf62956a5d641a3367edcd35e103edfcd",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733940128,
-        "narHash": "sha256-hmfXWj2GA9cj1QUkPFYtAAeohhs615zL4E3APy3FnvQ=",
+        "lastModified": 1734906472,
+        "narHash": "sha256-pWPRv/GA/X/iAwoE6gMNUqn/ZeJX1IeLPRpZI0tTPK0=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "3833097e50473a152dd614d4b468886840b4ea78",
+        "rev": "c77109d7e1ddbcdb87cafd32ce411f76328ae152",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364628,
-        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
+        "lastModified": 1734906259,
+        "narHash": "sha256-P79t/7HbACO4/PuJBroGpTptvCWJtXTv+gWsF+sM6MI=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "16e59c1eb13d9fb6de066f54e7555eb5e8a4aba5",
+        "rev": "0404833ea18d543df44df935ebf1b497310eb046",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734384247,
-        "narHash": "sha256-bl3YyJb2CgaeVKYq/l8j27vKdbkTpDNFDsnCl0dnNlY=",
+        "lastModified": 1735316583,
+        "narHash": "sha256-AiiUwHWHfEdpFzXy7l1x3zInCUa1xcRMrbZ1XRSkzwU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e6cf45cd1845368702e03b8912f4cc44ebba3322",
+        "rev": "8f15d45b120b33712f6db477fe5ffb18034d0ea8",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734384417,
-        "narHash": "sha256-noYeXcNQ15g1/gIJIYT2zdO66wzY5Z06PYz6BfKUZA8=",
+        "lastModified": 1734793513,
+        "narHash": "sha256-rrrHcXapXJvGFqX+L/Bb0182L25jofAZ0fm1FInvrTQ=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "90e87f7fcfcce4862826d60332cbc5e2f87e1f88",
+        "rev": "4d7367b6eee87397e2dbca2e78078dd0a4ef4c61",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734379367,
-        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -831,11 +831,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734422917,
-        "narHash": "sha256-0y7DRaXslhfqVKV8a/talYTYAe2NHOQhMZG7KMNRCtc=",
+        "lastModified": 1734907020,
+        "narHash": "sha256-p6HxwpRKVl1KIiY5xrJdjcEeK3pbmc///UOyV6QER+w=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "3e884d941ca819c1f2e50df8bdae0debded1ed87",
+        "rev": "d7f18dda5e511749fa1511185db3536208fb1a63",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1735394862,
-        "narHash": "sha256-6/4VTVdtg8/DJUy/FsOk+bSoqAeYwZGFnCexmNaPWk0=",
+        "lastModified": 1735585949,
+        "narHash": "sha256-0nT9kNyyQlhpMHakQLyINZoJAjRAui4WsbxrRev6Gwc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2b01a5bcf62956a5d641a3367edcd35e103edfcd",
+        "rev": "1989b0049f7fb714a2417dfb14d6b4f3d2a079d3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732482255,
-        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
+        "lastModified": 1736785676,
+        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
+        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`fc52a210`](https://github.com/nix-community/home-manager/commit/fc52a210b60f2f52c74eac41a8647c1573d2071d) | `` network-manager-applet: changed nm-applet description (#6311) ``      |
| [`0da8b6ba`](https://github.com/nix-community/home-manager/commit/0da8b6bae9b3179af68c72827541ef88cad413fc) | `` sway: allow sway specific hideEdgeBorders options (#6304) ``          |
| [`9616d81f`](https://github.com/nix-community/home-manager/commit/9616d81f98032d1ee9bec68ab4b6a8c833add88c) | `` mangohud: make `false` values actually disable (#6299) ``             |
| [`2532b500`](https://github.com/nix-community/home-manager/commit/2532b500c3ed2b8940e831039dcec5a5ea093afc) | `` ollama: add module (#5735) ``                                         |
| [`d4aebb94`](https://github.com/nix-community/home-manager/commit/d4aebb947a301b8da8654a804979a738c5c5da50) | `` todoman: add todoman module (#5252) ``                                |
| [`01f40d52`](https://github.com/nix-community/home-manager/commit/01f40d52d65318463d71aa485fe9ad6f26357b45) | `` zsh/prezto: add `package` option (#5938) ``                           |
| [`7e008565`](https://github.com/nix-community/home-manager/commit/7e00856596891850ba5ad4c5ecd2ed74468c08c5) | `` flake.lock: Update ``                                                 |
| [`54b330ac`](https://github.com/nix-community/home-manager/commit/54b330ac067e74314f8ca6b38af6fcfbd17f3e9e) | `` go: add telemetry options ``                                          |
| [`fcc4259c`](https://github.com/nix-community/home-manager/commit/fcc4259cdbcb76138b48ed36b4f41c521910db0d) | `` treewide: stub tests (#6275) ``                                       |
| [`456e599f`](https://github.com/nix-community/home-manager/commit/456e599f9101ed153dde268b4401c5d294ba6c8c) | `` wayfire: add module (#6066) ``                                        |
| [`45bcdbc9`](https://github.com/nix-community/home-manager/commit/45bcdbc910dc5131943bb6f7edb156617898fd1a) | `` gpg-agent: fix compatibility with sh when enableSshSupport (#6287) `` |
| [`5c430231`](https://github.com/nix-community/home-manager/commit/5c4302313d9207f7ec0886d68f8ff4a3c71209a1) | `` neomutt: added missing sort options (#6283) ``                        |
| [`20665c6e`](https://github.com/nix-community/home-manager/commit/20665c6efa83d71020c8730f26706258ba5c6b2a) | `` home-manager: remove path: URI type for flake default ``              |
| [`172b91bf`](https://github.com/nix-community/home-manager/commit/172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196) | `` Translate using Weblate (German) ``                                   |
| [`4795ebe6`](https://github.com/nix-community/home-manager/commit/4795ebe6cc6e5f60a3e66e3627b4f182ac4771b5) | `` Translate using Weblate (French) ``                                   |
| [`5ad12b6e`](https://github.com/nix-community/home-manager/commit/5ad12b6ea06b84e48f6b677957c74f32d47bdee0) | `` flake.lock: Update ``                                                 |
| [`0d7908bd`](https://github.com/nix-community/home-manager/commit/0d7908bd09165db6699908b7e3970f137327cbf0) | `` neomutt: Document how to bind Ctrl keys (#6254) ``                    |
| [`11ab0854`](https://github.com/nix-community/home-manager/commit/11ab08541e61ac3bbf2ab27229f68622629401df) | `` ghostty: validate configuration on change ``                          |
| [`a9987622`](https://github.com/nix-community/home-manager/commit/a9987622b7b93c82e147f198574e8e6ffbf5e327) | `` maintainers: updated username to midirhee12 ``                        |
| [`14cb0c8c`](https://github.com/nix-community/home-manager/commit/14cb0c8cfaa28d62a0e0cb4829e921635cd2b296) | `` fnott: use config.wayland.systemd.target ``                           |
| [`656ae5ab`](https://github.com/nix-community/home-manager/commit/656ae5aba2d48adfe5bb3aa8d433b9a50cfb2a11) | `` clipman: use config.wayland.systemd.target ``                         |
| [`a6db8c8f`](https://github.com/nix-community/home-manager/commit/a6db8c8f6c201df0cfb5482241368ac02a5b17f3) | `` hypridle: use config.wayland.systemd.target ``                        |
| [`da12f0b1`](https://github.com/nix-community/home-manager/commit/da12f0b143558490efc52b7f550e19d9fcf27909) | `` hyprpaper: use config.wayland.systemd.target ``                       |
| [`8f48fea0`](https://github.com/nix-community/home-manager/commit/8f48fea0f8a8392f4b81da07333342824fdb35c9) | `` avizo: use config.wayland.systemd.target ``                           |
| [`adcf0b62`](https://github.com/nix-community/home-manager/commit/adcf0b6281f4d8c00ea263c49f52a71130ee875f) | `` wob: use config.wayland.systemd.target ``                             |
| [`51ba4aac`](https://github.com/nix-community/home-manager/commit/51ba4aacec867a1ecc2b92bf5ecdc66dbf9eb6c2) | `` swayosd: use config.wayland.systemd.target ``                         |
| [`4cbc8a58`](https://github.com/nix-community/home-manager/commit/4cbc8a58ab94e5eea5fe3185837d6489579a7f68) | `` swaync: use config.wayland.systemd.target ``                          |
| [`d3c500a8`](https://github.com/nix-community/home-manager/commit/d3c500a8f8f88587c0867ba13ae6dba6e3c58cec) | `` kanshi: use config.wayland.systemd.target ``                          |
| [`8587c2ff`](https://github.com/nix-community/home-manager/commit/8587c2ff0ea82a93a265dbcbad7df88c80de1b9c) | `` waybar: use config.wayland.systemd.target ``                          |
| [`89fe48b1`](https://github.com/nix-community/home-manager/commit/89fe48b1c1c51d5616343b71822a45f894b16dcf) | `` swayidle: use config.wayland.systemd.target ``                        |
| [`0734cfab`](https://github.com/nix-community/home-manager/commit/0734cfab07a90a34bb91428e24646e5fe78d9e24) | `` wayland: add module ``                                                |
| [`1c8d4c8d`](https://github.com/nix-community/home-manager/commit/1c8d4c8d592e8fab4cff4397db5529ec6f078cf9) | `` mako: add center-left & center-right ``                               |
| [`7254063d`](https://github.com/nix-community/home-manager/commit/7254063d529d666f10d73ce3fe5756d6c325ddc3) | `` Update translation files ``                                           |
| [`12327fc3`](https://github.com/nix-community/home-manager/commit/12327fc3d83ee6c3f39b1b8852d9139fa4d2a176) | `` Add translation using Weblate (Tamil) ``                              |
| [`7f16e9c3`](https://github.com/nix-community/home-manager/commit/7f16e9c3cb00ca6df680917ab37ebf00177a19e9) | `` Translate using Weblate (Tamil) ``                                    |
| [`a6f37e57`](https://github.com/nix-community/home-manager/commit/a6f37e5785a5057ab43b4f5a64c590dcc709f043) | `` ghostty: fix configuration for bat syntax ``                          |
| [`1e68dc75`](https://github.com/nix-community/home-manager/commit/1e68dc759b3b3e0dc56589ecd3e58c3699ff9b27) | `` home-manager: move profile management ``                              |
| [`1e2a9d2d`](https://github.com/nix-community/home-manager/commit/1e2a9d2d29216f3512e6a02905b4f88f11bf5d0e) | `` format: ignore system and user git config ``                          |
| [`f4f8d09f`](https://github.com/nix-community/home-manager/commit/f4f8d09f909b4ef34afd9bad2284042d307bc95f) | `` home-manager: update copyright year ``                                |
| [`5f6aa268`](https://github.com/nix-community/home-manager/commit/5f6aa268e419d053c3d5025da740e390b12ac936) | `` ghostty: add module ``                                                |
| [`9a9fef31`](https://github.com/nix-community/home-manager/commit/9a9fef316ad191b3086edda465e850af282de4e0) | `` systemd: use sd-switch by default ``                                  |
| [`5518f9d4`](https://github.com/nix-community/home-manager/commit/5518f9d43919c255653b235150010da32faa60c0) | `` home-manager: make show news a bit more robust ``                     |
| [`59a4c43e`](https://github.com/nix-community/home-manager/commit/59a4c43e9ba6db24698c112720a58a334117de83) | `` bacon: fix configuration file location on Darwin ``                   |
| [`2ac770c0`](https://github.com/nix-community/home-manager/commit/2ac770c007cc5dc26e6fe472956e6a23134dd124) | `` flake.lock: Update ``                                                 |
| [`10e99c43`](https://github.com/nix-community/home-manager/commit/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2) | `` copyq: add option to disable XWayland ``                              |
| [`b7a7cd5d`](https://github.com/nix-community/home-manager/commit/b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a) | `` pqiv: fix condition for writing pqivrc file ``                        |
| [`19398e50`](https://github.com/nix-community/home-manager/commit/19398e505a80db1a1c41207ee89e1b1770c5dcf6) | `` lesspipe: allow configuring package ``                                |
| [`35b98d20`](https://github.com/nix-community/home-manager/commit/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84) | `` treewide: change pacien to euxane ``                                  |
| [`afbf007b`](https://github.com/nix-community/home-manager/commit/afbf007bb5e05b7837be5485e221ea50c4fd4f1b) | `` tests: add integration test for nh ``                                 |
| [`64272584`](https://github.com/nix-community/home-manager/commit/64272584091a47e3762d1bfb40638fbe58dd756d) | `` tests: change to wait for network.target ``                           |
| [`aa8c3d7f`](https://github.com/nix-community/home-manager/commit/aa8c3d7f7d6b61d3273e943d4fb8bddf7a647431) | `` tests: remove stray line ``                                           |
| [`f1b1786e`](https://github.com/nix-community/home-manager/commit/f1b1786ea77739dcd181b920d430e30fb1608b8a) | `` swayr: avoid IFD ``                                                   |
| [`8264bfe3`](https://github.com/nix-community/home-manager/commit/8264bfe3a064d704c57df91e34b795b6ac7bad9e) | `` mu: add integration tests ``                                          |
| [`7349b015`](https://github.com/nix-community/home-manager/commit/7349b01505d18cd60ba0e573e78c234b742056ef) | `` mu: reinitialize when personal addresses change ``                    |
| [`8bea1a20`](https://github.com/nix-community/home-manager/commit/8bea1a2005c64a8c9c430d0dddb6b2e5db5f6f12) | `` nixgl: forward override calls to wrapped package ``                   |
| [`edb8b00e`](https://github.com/nix-community/home-manager/commit/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4) | `` Translate using Weblate (Czech) ``                                    |
| [`1f74238a`](https://github.com/nix-community/home-manager/commit/1f74238a4c8e534a1b6be72cb5153043071ffd17) | `` xresources: allow floating point values ``                            |
| [`cb27edb5`](https://github.com/nix-community/home-manager/commit/cb27edb5221d2f2920a03155f8becc502cf60e35) | `` waybar: add systemd restart triggers ``                               |
| [`f47b6c15`](https://github.com/nix-community/home-manager/commit/f47b6c153ad31187a519bd569ccbcb20acb16ce0) | `` cavalier: add module ``                                               |
| [`c903b1f6`](https://github.com/nix-community/home-manager/commit/c903b1f6fbfc2039963806df896f698331b77aa8) | `` flake.lock: Update ``                                                 |
| [`51160a09`](https://github.com/nix-community/home-manager/commit/51160a097a850839b7eae7ef08d0d3e7e353dfc3) | `` thunderbird: implement `extensions` for profiles ``                   |
| [`f342df3a`](https://github.com/nix-community/home-manager/commit/f342df3ad938f205a913973b832f52c12546aac6) | `` flake.lock: Update ``                                                 |
| [`db9a98e1`](https://github.com/nix-community/home-manager/commit/db9a98e178b57a8aff46b3482dfccb3f4d8d4ce3) | `` pay-respects: add module ``                                           |
| [`99f54cdf`](https://github.com/nix-community/home-manager/commit/99f54cdfef395bb3de1c7b8dd422412de65b038d) | `` yazi: fix example option for settings ``                              |
| [`1395379a`](https://github.com/nix-community/home-manager/commit/1395379a7a36e40f2a76e7b9936cc52950baa1be) | `` home-manager: improve path handling when building news ``             |
| [`832920a6`](https://github.com/nix-community/home-manager/commit/832920a60833533eaabcc93ab729801bf586fa0c) | `` thunderbird: add profileVersion ``                                    |
| [`83ecd509`](https://github.com/nix-community/home-manager/commit/83ecd50915a09dca928971139d3a102377a8d242) | `` docs: fix typo in 24.11 release notes ``                              |
| [`66c5d8b6`](https://github.com/nix-community/home-manager/commit/66c5d8b62818ec4c1edb3e941f55ef78df8141a8) | `` zed-editor: fix always generating settings.json ``                    |
| [`3066cc58`](https://github.com/nix-community/home-manager/commit/3066cc58f552421a2c5414e78407fa5603405b1e) | `` kanshi: dont write config in absence of nix settings (#6198) ``       |
| [`e526fd2b`](https://github.com/nix-community/home-manager/commit/e526fd2b1a40e4ca0b5e07e87b8c960281c67412) | `` gnome-shell: fix extensions' default (#6199) ``                       |
| [`15151bb5`](https://github.com/nix-community/home-manager/commit/15151bb5e7d6e352247ecaeeeefc34d0f306b287) | `` gpg: fix hash of test (#6200) ``                                      |
| [`6e5b2d9e`](https://github.com/nix-community/home-manager/commit/6e5b2d9e8014b5572e3367937a329e7053458d34) | `` home-manager: support username with special chars (#5609) ``          |
| [`f26aa4b7`](https://github.com/nix-community/home-manager/commit/f26aa4b76fb7606127032d33ac73d7d507d82758) | `` gpg-agent: fix GCR DBus package note ``                               |
| [`c6a5fbfd`](https://github.com/nix-community/home-manager/commit/c6a5fbfd99bccfafbe99a6bb87b351c8fb7de70a) | `` qt: install kio when qt.platformTheme = "kde" ``                      |
| [`8772bae5`](https://github.com/nix-community/home-manager/commit/8772bae58c0a1390727aaf13802debfa29757d67) | `` nushell: allow installing plugins ``                                  |
| [`e952e949`](https://github.com/nix-community/home-manager/commit/e952e94955dcc6fa2120c1430789fc41363f5237) | `` atuin: Prepare for daemon socket path in 18.4.0 ``                    |
| [`77a792a0`](https://github.com/nix-community/home-manager/commit/77a792a0418227e69a2ba26728b47f2b8cf3b6ec) | `` atuin: Do not hard code prefix for daemon socket path ``              |
| [`9ebaa80a`](https://github.com/nix-community/home-manager/commit/9ebaa80a227eaca9c87c53ed515ade013bc2bca9) | `` thunderbird: set the correct SMTP server for aliases (#6177) ``       |
| [`f63c15c1`](https://github.com/nix-community/home-manager/commit/f63c15c137f9e446af897c15218c1af9f06d91ad) | `` isync/mbsync: update module for 1.5.0 changes (#5918) ``              |
| [`d00c6f6d`](https://github.com/nix-community/home-manager/commit/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a) | `` nix: simplify tests ``                                                |
| [`63eb786e`](https://github.com/nix-community/home-manager/commit/63eb786e047fbb101041103f86162cd72d105d79) | `` xresources: simplify tests ``                                         |
| [`0b42cc1b`](https://github.com/nix-community/home-manager/commit/0b42cc1b1c7a38f32334f217eadbc7b83b3ef44c) | `` cmus: reduce test closure ``                                          |
| [`953521f7`](https://github.com/nix-community/home-manager/commit/953521f759fd746190ae2d2d052183296425b27b) | `` fcitx5: fix package reference in test ``                              |
| [`65912bc6`](https://github.com/nix-community/home-manager/commit/65912bc6841cf420eb8c0a20e03df7cbbff5963f) | `` imapnotify: provide an option for setting PATH ``                     |
| [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) | `` starship: replace `eval` with `source` for fish ``                    |
| [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) | `` starship: add `enableInteractive` option for fish ``                  |
| [`1cd17a2f`](https://github.com/nix-community/home-manager/commit/1cd17a2f76f7711b06d5d59f1746cef602974498) | `` mangohud: fix a non-working example ``                                |
| [`3a7fc9cd`](https://github.com/nix-community/home-manager/commit/3a7fc9cd71a844aae9c6b6bb44700cea9539bc13) | `` zsh: make autosuggest strategy accept more options ``                 |
| [`ad48eb25`](https://github.com/nix-community/home-manager/commit/ad48eb25cd0b00ce730da00fa1f8e6e6c27b397d) | `` etesync-dav: update default server URL ``                             |
| [`b1c19f1d`](https://github.com/nix-community/home-manager/commit/b1c19f1dcbc2429c16d5e6259dbff4f12dd8a89d) | `` home-cursor: use `profileExtra` instead of `initExtra` ``             |
| [`30f66eaa`](https://github.com/nix-community/home-manager/commit/30f66eaa3209e13f32f98df5a150542baf2d72af) | `` xresources: use `profileExtra` instead of `initExtra` ``              |
| [`6c3a7a0b`](https://github.com/nix-community/home-manager/commit/6c3a7a0b72c19ec994b85c57a1712d177bd809b2) | `` qt: reduce test closure ``                                            |
| [`8f4f57f9`](https://github.com/nix-community/home-manager/commit/8f4f57f9a67367881b1a36f93856ffef8646d428) | `` qt: update tooling for Plasma 6 ``                                    |
| [`70803283`](https://github.com/nix-community/home-manager/commit/70803283187c8f775ff561be4117e5b1a11b296e) | `` Translate using Weblate (Finnish) ``                                  |
| [`5b5de433`](https://github.com/nix-community/home-manager/commit/5b5de4338fad32dc709c900b4dcbbcd98b20dc4c) | `` kakoune: fix color scheme package XDG file ``                         |
| [`256ec265`](https://github.com/nix-community/home-manager/commit/256ec2653e79363022a6042285dde3935816cea4) | `` flake.lock: Update ``                                                 |
| [`dfdf59b2`](https://github.com/nix-community/home-manager/commit/dfdf59b2d539941aea5c26666c9ab809c1dc34df) | `` atuin: make daemon log level configurable ``                          |
| [`f8bc330a`](https://github.com/nix-community/home-manager/commit/f8bc330a13f80e13e70967bca0e674f711218ea2) | `` atuin: capitalize mentions of "atuin" ``                              |
| [`c56aa0f5`](https://github.com/nix-community/home-manager/commit/c56aa0f51d058f41a7ba0c45bd3b6d9d244c0396) | `` atuin: assert version >= 18.2.0 when daemon is enabled ``             |
| [`33c236f1`](https://github.com/nix-community/home-manager/commit/33c236f1d5eb3d1a3df202540794d590c2fe0a2f) | `` atuin: add water-sucks as maintainer ``                               |
| [`092b81b9`](https://github.com/nix-community/home-manager/commit/092b81b95615919b36cbb0e690dda8583b31013e) | `` atuin: configure daemon using systemd and launchd ``                  |
| [`bf23fe41`](https://github.com/nix-community/home-manager/commit/bf23fe41082aa0289c209169302afd3397092f22) | `` tmux: add 'focusEvents' ``                                            |
| [`873e39d5`](https://github.com/nix-community/home-manager/commit/873e39d5f4437d2f3ab06881fea8e63e45e1d011) | `` podman-container: fix tests and failing podman 5.3.0 service ``       |
| [`d2e2bda6`](https://github.com/nix-community/home-manager/commit/d2e2bda6c050a61d51b8e395ad66b8fa48318e07) | `` nix-your-shell: fix creating required directory ``                    |
| [`c1fee8d4`](https://github.com/nix-community/home-manager/commit/c1fee8d4a60b89cae12b288ba9dbc608ff298163) | `` alot: make package used by module configurable ``                     |
| [`86327350`](https://github.com/nix-community/home-manager/commit/863273505016a1e88e4ffaec48d1b767104c5652) | `` kubecolor: add module ``                                              |
| [`e71e678d`](https://github.com/nix-community/home-manager/commit/e71e678d18d1a24e01d823ccb72df13f9e82f65b) | `` nix-your-shell: add module ``                                         |
| [`7f78e2d1`](https://github.com/nix-community/home-manager/commit/7f78e2d1c6a9db76444e02a73f0669ebb79f8833) | `` yazi: update keymap config ``                                         |
| [`441fae84`](https://github.com/nix-community/home-manager/commit/441fae847ddfe20f9f9a4c47345691a205bb772c) | `` zsh-abbr: add package option ``                                       |
| [`4964f3c6`](https://github.com/nix-community/home-manager/commit/4964f3c6fc17ae4578e762d3dc86b10fe890860e) | `` home-manager: prepare 24.11 release ``                                |
| [`8eeda281`](https://github.com/nix-community/home-manager/commit/8eeda281e70cbadabb7f0095c5f34e354e85f307) | `` flake.lock: Update ``                                                 |
| [`819f6822`](https://github.com/nix-community/home-manager/commit/819f682269f4e002884702b87e445c82840c68f2) | `` lorri: fix ReadWritePaths for new gcroots behavior ``                 |
| [`2f7739d0`](https://github.com/nix-community/home-manager/commit/2f7739d01080feb4549524e8f6927669b61c6ee3) | `` kakoune: add colorSchemePackage option ``                             |
| [`b7219652`](https://github.com/nix-community/home-manager/commit/b7219652387ce4331ae49ddac8b0286f50e0ed68) | `` mopidy: ignore collisions between extensions ``                       |
| [`de7d67b8`](https://github.com/nix-community/home-manager/commit/de7d67b8bae8aa2ac920fa10918c89ce44b66d00) | `` mopidy: make makeWrapper a native build input ``                      |
| [`21396857`](https://github.com/nix-community/home-manager/commit/21396857fdceb61239a7ae67b9be4dbfd90c12c1) | `` kdeconnect: upgrade default version ``                                |
| [`f83dc9f2`](https://github.com/nix-community/home-manager/commit/f83dc9f25a5915c70b013102e30f3ee2a72ba633) | `` tmux: set `sensibleOnTop = false` as a default ``                     |
| [`0941a2e1`](https://github.com/nix-community/home-manager/commit/0941a2e14486ee30e2088afa1d2869f2486dd3b8) | `` flake.lock: Update ``                                                 |