### PR TITLE
chore(flake/hyprland): `5329298b` -> `db249648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731774881,
-        "narHash": "sha256-1Dxryiw8u2ejntxrrv3sMtIE8WHKxmlN4KeH+uMGbmc=",
+        "lastModified": 1731959031,
+        "narHash": "sha256-TGcvIjftziC1CjuiHCzrYDwmOoSFYIhdiKmLetzB5L0=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "b31a6a4da8199ae3489057db7d36069a70749a56",
+        "rev": "4468981c1c50999f315baa1508f0e53c4ee70c52",
         "type": "github"
       },
       "original": {
@@ -321,11 +321,42 @@
         "type": "github"
       }
     },
+    "hyprgraphics": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733248371,
+        "narHash": "sha256-FFLJzFTyNhS7tBEEECx0B8Ye/bpmxhFVEKlECgMLc6c=",
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "rev": "cc95e5babc6065bc3ab4cd195429a9900836ef13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "type": "github"
+      }
+    },
     "hyprland": {
       "inputs": {
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
+        "hyprgraphics": "hyprgraphics",
         "hyprland-protocols": "hyprland-protocols",
+        "hyprland-qtutils": "hyprland-qtutils",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -335,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1732737540,
-        "narHash": "sha256-ORogf5yeqxar+fMJek+rpUgfnCOYcoeomvczo/tYOcE=",
+        "lastModified": 1734219437,
+        "narHash": "sha256-NVQIAvfSpBSJaJ4BP1cE1yVGjCuvXs0NN1G1t+f52Ss=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5329298b522e3cc1201894909443775b00aeb336",
+        "rev": "db249648776875ce3142141d0d3055e43ce606aa",
         "type": "github"
       },
       "original": {
@@ -370,6 +401,35 @@
       "original": {
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-qtutils": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733472316,
+        "narHash": "sha256-PvXiFLIExJEJj+goLbIuXLTN5CSDSAUsAfiYSdbbWg0=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
+        "rev": "969427419276c7ee170301ef1ebe0f68eb6eb2e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
         "type": "github"
       }
     },
@@ -414,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731702627,
-        "narHash": "sha256-+JeO9gevnXannQxMfR5xzZtF4sYmSlWkX/BPmPx0mWk=",
+        "lastModified": 1732288281,
+        "narHash": "sha256-XTU9B53IjGeJiJ7LstOhuxcRjCOFkQFl01H78sT9Lg4=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e911361a687753bbbdfe3b6a9eab755ecaf1d9e1",
+        "rev": "b26f33cc1c8a7fd5076e19e2cce3f062dca6351c",
         "type": "github"
       },
       "original": {
@@ -546,11 +606,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {
@@ -634,11 +694,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -771,11 +831,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731703417,
-        "narHash": "sha256-rheDc/7C+yI+QspYr9J2z9kQ5P9F4ATapI7qyFAe1XA=",
+        "lastModified": 1733157064,
+        "narHash": "sha256-NetqJHAN4bbZDQADvpep+wXk2AbMZ2bN6tINz8Kpz6M=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "8070f36deec723de71e7557441acb17e478204d3",
+        "rev": "fd85ef39369f95eed67fdf3f025e86916edeea2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| [`db249648`](https://github.com/hyprwm/Hyprland/commit/db249648776875ce3142141d0d3055e43ce606aa) | `` xwayland: Support cross DnD from Wayland (#8708) ``                                            |
| [`9f7a96b9`](https://github.com/hyprwm/Hyprland/commit/9f7a96b997d90c4c188f3837e02859a25a05611e) | `` core/data: Use pointer focus for DnD operations (#8707) ``                                     |
| [`3cba4ba4`](https://github.com/hyprwm/Hyprland/commit/3cba4ba44e7ba3cc8bb67ac71bc61245b5aca347) | `` hyprctl: avoid crash on null pwuid ``                                                          |
| [`8237627f`](https://github.com/hyprwm/Hyprland/commit/8237627f3a7255e0dbae61a8090a81596d0cba8a) | `` compositor: fix monitor arrangement with mixed auto directions ``                              |
| [`35e134e5`](https://github.com/hyprwm/Hyprland/commit/35e134e5700b7adb393ba91127bd11188259b901) | `` hyprctl: add an inhibitingIdle field to windows ``                                             |
| [`452a7e69`](https://github.com/hyprwm/Hyprland/commit/452a7e6905de61f076065ef4c294dc62f86327ae) | `` dispatchers: Add an option to prioritize focus change within groups with movefocus  (#8601) `` |
| [`61a51bb4`](https://github.com/hyprwm/Hyprland/commit/61a51bb4ef5ff38a8482933da1756bf31d4475be) | `` snap: bias reserved area when its size is greater than zero (#8694) ``                         |
| [`aefaeedf`](https://github.com/hyprwm/Hyprland/commit/aefaeedf5e3f773c923373795267c1633141566c) | `` data-device: fixup wrong box expansion ``                                                      |
| [`cef5e6dd`](https://github.com/hyprwm/Hyprland/commit/cef5e6dd7ca7008456cf63a76776550974de1612) | `` layersurface: use lastMonitor and not monitor from cursor for new ls ``                        |
| [`7c03e9d3`](https://github.com/hyprwm/Hyprland/commit/7c03e9d376abe5308c47772b4c17a9c345788f60) | `` core/data-device: expand damage region to fix minor px errors ``                               |
| [`df956a0f`](https://github.com/hyprwm/Hyprland/commit/df956a0f6fbcfd7397b2d7b86883c0936c7795ec) | `` windowrules: add rules for mouse and touchpad scroll factors (#8655) ``                        |
| [`33f271c2`](https://github.com/hyprwm/Hyprland/commit/33f271c29a0069a95755b1d3252aeebe0fd85287) | `` hyprpm: target installed instead of running version (#8634) ``                                 |
| [`e8923109`](https://github.com/hyprwm/Hyprland/commit/e89231095383404853cef93d4aa7230a71a59560) | `` workspace: update hasFullscreenWindow in updateWindows ``                                      |
| [`4d05677e`](https://github.com/hyprwm/Hyprland/commit/4d05677e8d398b6fa144eae7a98ad4f2a54acb92) | `` config: add 'force' option for 'cursor:warp_on_change_workspace' (#8681) ``                    |
| [`c16044a5`](https://github.com/hyprwm/Hyprland/commit/c16044a5c88ce9a42987b849068a66c11873575d) | `` core: Fix workspace selector parsing (#8687) ``                                                |
| [`d94d8b4a`](https://github.com/hyprwm/Hyprland/commit/d94d8b4ab26a8691a70922f43512f0484c086d85) | `` windows: allow replacing existing fullscreen (#8566) ``                                        |
| [`bb5c3f27`](https://github.com/hyprwm/Hyprland/commit/bb5c3f27023e0702642b72d1869427b9b0ff72e0) | `` core/output: don't send enter too aggresively ``                                               |
| [`0a27af8c`](https://github.com/hyprwm/Hyprland/commit/0a27af8cd190315c1f13363ebd11e83d30455d48) | `` crashreporter: avoid clang warning ``                                                          |
| [`c106f454`](https://github.com/hyprwm/Hyprland/commit/c106f454c136ecca47f84c659c58e19670050412) | `` CI/Nix: temporarily disable cross build ``                                                     |
| [`875b598a`](https://github.com/hyprwm/Hyprland/commit/875b598a33592ca1aad27bfa76b7ca033665228e) | `` github: mention PR guidelines in the template ``                                               |
| [`8bbeee11`](https://github.com/hyprwm/Hyprland/commit/8bbeee11734d3ba8e2cf15d19cb3c302f8bfdbf2) | `` core: Add clang-tidy (#8664) ``                                                                |
| [`b1e5cc66`](https://github.com/hyprwm/Hyprland/commit/b1e5cc66bdb20b002c93479490c3a317552210b3) | `` core: Add support for hyprqtutils' update screen (#8651) ``                                    |
| [`5ff02902`](https://github.com/hyprwm/Hyprland/commit/5ff02902ee830d29ededdb790ed5c8ef7aa111ed) | `` snap: use the bit mask to check if snapping occurred (#8659) ``                                |
| [`cccca7c0`](https://github.com/hyprwm/Hyprland/commit/cccca7c02e0846eb4386dc26bb2d99f921c6114e) | `` renderer: drop requesting OUT_FENCE_PTR ``                                                     |
| [`10a4365f`](https://github.com/hyprwm/Hyprland/commit/10a4365f7d2674d0e9180a3bddf535acb95eae70) | `` Nix: create TAG info from version ``                                                           |
| [`a7a6eedc`](https://github.com/hyprwm/Hyprland/commit/a7a6eedc2139564abc1fe09feee1ff32b53e1081) | `` core: move version include to hyprctl ``                                                       |
| [`888bdf4e`](https://github.com/hyprwm/Hyprland/commit/888bdf4e23655d014b22da44f1235b2a045615a9) | `` hyprctl: add directScanout to hyprctl monitors ``                                              |
| [`ceef4fb3`](https://github.com/hyprwm/Hyprland/commit/ceef4fb3a5efe1617790f56e2701846a21c2533d) | `` core: feeling a bit quirky today. ``                                                           |
| [`22f7d6f1`](https://github.com/hyprwm/Hyprland/commit/22f7d6f1424c296b297df87bf2accdfefac4af33) | `` core: add a few festive splashes ``                                                            |
| [`f9e4998a`](https://github.com/hyprwm/Hyprland/commit/f9e4998a6d7713b19947b0db2c43ad88c5b71d80) | `` snap: check which corner is being grabbed for monitor snapping (#8637) ``                      |
| [`3c617ce3`](https://github.com/hyprwm/Hyprland/commit/3c617ce33c64cb43049489598b6391911eed7070) | `` internal: fixup some missed updateColorsOk() calls ``                                          |
| [`f6ac755c`](https://github.com/hyprwm/Hyprland/commit/f6ac755cf76750b8ee53389c54ef653590462c1c) | `` cleanup: Revert use doLater instead of adding idle event handlers (#8624) ``                   |
| [`320144ae`](https://github.com/hyprwm/Hyprland/commit/320144ae7288fe23686935ebb235d9fe0c900862) | `` core: move colorspace handling to oklab (#8635) ``                                             |
| [`92186898`](https://github.com/hyprwm/Hyprland/commit/92186898c0ca1b3f72922b72c4af1723f0d9b888) | `` version: add link versions for other utils (#8619) ``                                          |
| [`10a9fec7`](https://github.com/hyprwm/Hyprland/commit/10a9fec7fc8e77479a599985c776a8a184311cd6) | `` master: make center ignore reserved areas (#8625) ``                                           |
| [`6d754445`](https://github.com/hyprwm/Hyprland/commit/6d7544458d0fafcae410c1978a0cabce2fb4a346) | `` cleanup: use doLater instead of adding idle event handlers (#8624) ``                          |
| [`d26439a0`](https://github.com/hyprwm/Hyprland/commit/d26439a0fe5594fb26d5a3c01571f9490a9a2d2c) | `` nix: update flake ``                                                                           |
| [`ef6b0c81`](https://github.com/hyprwm/Hyprland/commit/ef6b0c81c914bdc9b56c2674273698f065518993) | `` cleanup: remove leftover var in ThreadManager.cpp (#8611) ``                                   |
| [`8f83d29f`](https://github.com/hyprwm/Hyprland/commit/8f83d29f00bfa89d1e8fe94b4dda98fe898b6b0e) | `` renderer: restore discard mode after IME render pass ``                                        |
| [`22bf2853`](https://github.com/hyprwm/Hyprland/commit/22bf2853e6271932f073961f3dbeb0f9ff48493e) | `` hyprpm: fix incomplete unmet dependencies message ``                                           |
| [`5963970b`](https://github.com/hyprwm/Hyprland/commit/5963970be54c92fdebdbcebdeb76cf6de5e7e717) | `` descriptions: change allow_pin_fullscreen value to false (#8592) ``                            |
| [`8b51eeb7`](https://github.com/hyprwm/Hyprland/commit/8b51eeb7aef8b25de35a0d460f28f4d67c017866) | `` core: fix compilation outside stdlibc++ ``                                                     |