### PR TITLE
chore(flake/hyprland): `31422ae2` -> `2b01a5bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734400729,
-        "narHash": "sha256-Bf+oya0BuleVXYGIWsb0eWnrK6s0aiesOsI7Mpj1pMU=",
+        "lastModified": 1734906446,
+        "narHash": "sha256-6OWluVE2A8xi+8V3jN9KA72RCgJjYdyyuLBUjxZ2q2U=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "a132fa41be7ebe797ad758e84d9df068151a723b",
+        "rev": "eecb74dc79bb6752a2a507e6edee3042390a6091",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364709,
-        "narHash": "sha256-+2bZJL2u5hva7rSp65OfKJBK+k03T6GB/NCvpoS1OOo=",
+        "lastModified": 1734906540,
+        "narHash": "sha256-vQ/L9hZFezC0LquLo4TWXkyniWtYBlFHAKIsDc7PYJE=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "f388aacd22be4a6e4d634fbaf6f75eb0713d239a",
+        "rev": "69270ba8f057d55b0e6c2dca0e165d652856e613",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733684019,
-        "narHash": "sha256-2kYREgmSmbLsmDpLEq96hxVAU3qz8aCvVhF65yCFZHY=",
+        "lastModified": 1734906236,
+        "narHash": "sha256-vH/ysV2ONGQgYZPtcJKwc8jJivzyVxru2aaOxC20ZOE=",
         "owner": "hyprwm",
         "repo": "hyprgraphics",
-        "rev": "fb2c0268645a77403af3b8a4ce8fa7ba5917f15d",
+        "rev": "6dea3fba08fd704dd624b6d4b261638fb4003c9c",
         "type": "github"
       },
       "original": {
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1734822454,
-        "narHash": "sha256-VhBUmov3V3BoVd8dJXvqjvskIRjJ7f8JadEh3T1WNBw=",
+        "lastModified": 1735394862,
+        "narHash": "sha256-6/4VTVdtg8/DJUy/FsOk+bSoqAeYwZGFnCexmNaPWk0=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "31422ae25dee33dd000798b64a80bd7fd08d2ece",
+        "rev": "2b01a5bcf62956a5d641a3367edcd35e103edfcd",
         "type": "github"
       },
       "original": {
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733940128,
-        "narHash": "sha256-hmfXWj2GA9cj1QUkPFYtAAeohhs615zL4E3APy3FnvQ=",
+        "lastModified": 1734906472,
+        "narHash": "sha256-pWPRv/GA/X/iAwoE6gMNUqn/ZeJX1IeLPRpZI0tTPK0=",
         "owner": "hyprwm",
         "repo": "hyprland-qtutils",
-        "rev": "3833097e50473a152dd614d4b468886840b4ea78",
+        "rev": "c77109d7e1ddbcdb87cafd32ce411f76328ae152",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734364628,
-        "narHash": "sha256-ii8fzJfI953n/EmIxVvq64ZAwhvwuuPHWfGd61/mJG8=",
+        "lastModified": 1734906259,
+        "narHash": "sha256-P79t/7HbACO4/PuJBroGpTptvCWJtXTv+gWsF+sM6MI=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "16e59c1eb13d9fb6de066f54e7555eb5e8a4aba5",
+        "rev": "0404833ea18d543df44df935ebf1b497310eb046",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734384247,
-        "narHash": "sha256-bl3YyJb2CgaeVKYq/l8j27vKdbkTpDNFDsnCl0dnNlY=",
+        "lastModified": 1735316583,
+        "narHash": "sha256-AiiUwHWHfEdpFzXy7l1x3zInCUa1xcRMrbZ1XRSkzwU=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e6cf45cd1845368702e03b8912f4cc44ebba3322",
+        "rev": "8f15d45b120b33712f6db477fe5ffb18034d0ea8",
         "type": "github"
       },
       "original": {
@@ -499,11 +499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734384417,
-        "narHash": "sha256-noYeXcNQ15g1/gIJIYT2zdO66wzY5Z06PYz6BfKUZA8=",
+        "lastModified": 1734793513,
+        "narHash": "sha256-rrrHcXapXJvGFqX+L/Bb0182L25jofAZ0fm1FInvrTQ=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "90e87f7fcfcce4862826d60332cbc5e2f87e1f88",
+        "rev": "4d7367b6eee87397e2dbca2e78078dd0a4ef4c61",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734379367,
-        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -831,11 +831,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734422917,
-        "narHash": "sha256-0y7DRaXslhfqVKV8a/talYTYAe2NHOQhMZG7KMNRCtc=",
+        "lastModified": 1734907020,
+        "narHash": "sha256-p6HxwpRKVl1KIiY5xrJdjcEeK3pbmc///UOyV6QER+w=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "3e884d941ca819c1f2e50df8bdae0debded1ed87",
+        "rev": "d7f18dda5e511749fa1511185db3536208fb1a63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
| [`2b01a5bc`](https://github.com/hyprwm/Hyprland/commit/2b01a5bcf62956a5d641a3367edcd35e103edfcd) | `` xwayland: don't create an abstract unix domain socket on linux (#8874) ``       |
| [`8d4c18d7`](https://github.com/hyprwm/Hyprland/commit/8d4c18d723d18f5bf5190b62b562301860df74f7) | `` core: refactor/improve monitor mode selection (#8804) ``                        |
| [`c600e1aa`](https://github.com/hyprwm/Hyprland/commit/c600e1aaff293303c8256aca7d2889fc4289e8c2) | `` [gha] Nix: update inputs ``                                                     |
| [`cca0adf6`](https://github.com/hyprwm/Hyprland/commit/cca0adf6a37c33fb12514b7935fa372fda27d97f) | `` snap: revert #8659, use bounds checking instead of bit mask (#8872) ``          |
| [`534adad6`](https://github.com/hyprwm/Hyprland/commit/534adad6b1940fcf0929a59be62dc78e5effaccc) | `` pass: scale blur regions properly ``                                            |
| [`775111b6`](https://github.com/hyprwm/Hyprland/commit/775111b6032185c9ef164d7ba1417a875c1d0287) | `` foreign-toplevel: update active on null window focus (#8860) ``                 |
| [`85632e7c`](https://github.com/hyprwm/Hyprland/commit/85632e7c334f6621b7aa08f295483f3358e42c57) | `` internal: update window position/size after changing fullscreenstate (#8865) `` |
| [`43ca6677`](https://github.com/hyprwm/Hyprland/commit/43ca66779b7d267cc6c52bdea75d3ff8eb60132f) | `` hyprpm: use glaze to parse hyprctl plugin list (#8812) ``                       |
| [`e75e2cda`](https://github.com/hyprwm/Hyprland/commit/e75e2cdac79417ffdbbbe903f72668953483a4e7) | `` functionHooks: wait for hyprland pages before returning addr for trampo ``      |
| [`2eaa4d80`](https://github.com/hyprwm/Hyprland/commit/2eaa4d80a0ecb56fc16c8ad4077b1b1a7d28281f) | `` debug: fix overlay not rendering ``                                             |
| [`dddb64dc`](https://github.com/hyprwm/Hyprland/commit/dddb64dc353ec9ef73be22d1cc1441782fb44068) | `` internal: added reference to CTimer class in KeybindManager (#8836) ``          |
| [`1a3d17da`](https://github.com/hyprwm/Hyprland/commit/1a3d17da9150f255ff2144cbe8317c0200de0ee4) | `` debug: fix ISDEBUG checking (#8823) ``                                          |
| [`2a24a611`](https://github.com/hyprwm/Hyprland/commit/2a24a61126dcebd2e1f7862e5c21c105900110ac) | `` pass: improve blur region detection ``                                          |
| [`2e2e2e2c`](https://github.com/hyprwm/Hyprland/commit/2e2e2e2cad97eb017ab02f8a67b751e0abe3bb72) | `` monitor: bring back old description behavior ``                                 |
| [`68a5842f`](https://github.com/hyprwm/Hyprland/commit/68a5842f06e33d381e9afbf9c9492ba5a7aa2d0f) | `` Nix: fix TAG substitution ``                                                    |
| [`5f7ad767`](https://github.com/hyprwm/Hyprland/commit/5f7ad767dbf0bac9ddd6bf6c825fb9ed7921308a) | `` flake.lock: update ``                                                           |
| [`a4a4ffff`](https://github.com/hyprwm/Hyprland/commit/a4a4fffffb74eb40a8ab9cf4606a3edbb4e9fbd9) | `` renderer: allow plugins to know what window was rendered in post ``             |
| [`1830296d`](https://github.com/hyprwm/Hyprland/commit/1830296df3515222bf0f03b90822e3b23e74b775) | `` debug: add debug:pass for debugging the render pass ``                          |
| [`e536b022`](https://github.com/hyprwm/Hyprland/commit/e536b02248f370971716b744968776f6880528be) | `` Renderer: rewrite render scheduling (#8683) ``                                  |
| [`1cc1a46c`](https://github.com/hyprwm/Hyprland/commit/1cc1a46c2e154a27750b81307040d3bf7ff0f64f) | `` core: fade in windows when they are brought from invisible workspaces ``        |