### PR TITLE
chore(flake/nixpkgs): `d3c42f18` -> `634fd468`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1735291276,
+        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`055ed209`](https://github.com/NixOS/nixpkgs/commit/055ed2091b3ebfc88c898d3d68ab873387a5ce8b) | `` nixosTests.gitlab: do not block nixos-unstable on aarch64 ``                                      |
| [`c847ffcb`](https://github.com/NixOS/nixpkgs/commit/c847ffcbe3014c58afe6f20da8b349606e276553) | `` terraform-providers.acme: 2.28.2 -> 2.29.0 ``                                                     |
| [`1c19588e`](https://github.com/NixOS/nixpkgs/commit/1c19588ef9e3fadd4441316916e534b452ad64e3) | `` terraform-providers.equinix: 2.11.0 -> 3.1.0 ``                                                   |
| [`aae2240e`](https://github.com/NixOS/nixpkgs/commit/aae2240ea8432515594fda0c275734b956f881e0) | `` terraform-providers.spotinst: 1.201.0 -> 1.202.0 ``                                               |
| [`510c7de6`](https://github.com/NixOS/nixpkgs/commit/510c7de636bd62c119d0a18787e3ca6a0484ca1e) | `` terraform-providers.tfe: 0.61.0 -> 0.62.0 ``                                                      |
| [`e43274f4`](https://github.com/NixOS/nixpkgs/commit/e43274f4ee07a81e4d1af772423a7566c65ac9a1) | `` terraform-providers.yandex: 0.134.0 -> 0.135.0 ``                                                 |
| [`e4883c87`](https://github.com/NixOS/nixpkgs/commit/e4883c87c2c17922e5767dbf59e6b43f4a935506) | `` terraform-providers.alicloud: 1.237.0 -> 1.239.0 ``                                               |
| [`5334abe1`](https://github.com/NixOS/nixpkgs/commit/5334abe1989f64d692921b13f32a5d88e465f2ba) | `` terraform-providers.tencentcloud: 1.81.147 -> 1.81.152 ``                                         |
| [`14d832b9`](https://github.com/NixOS/nixpkgs/commit/14d832b9093af49d06a156d6715ad4043716afb8) | `` terraform-providers.buildkite: 1.13.1 -> 1.15.1 ``                                                |
| [`4f26fb98`](https://github.com/NixOS/nixpkgs/commit/4f26fb984b38604a3f4274016845e27bf2ed9b8e) | `` terraform-providers.digitalocean: 2.45.0 -> 2.46.1 ``                                             |
| [`3eacf5e6`](https://github.com/NixOS/nixpkgs/commit/3eacf5e6d7ddb6070b2cdcb3b4ba2fa32c1c7c12) | `` terraform-providers.azurerm: 4.13.0 -> 4.14.0 ``                                                  |
| [`c8b88a67`](https://github.com/NixOS/nixpkgs/commit/c8b88a6749fe9199f7490345c7918229cded7571) | `` terraform-providers.oci: 6.18.0 -> 6.21.0 ``                                                      |
| [`af68dd3f`](https://github.com/NixOS/nixpkgs/commit/af68dd3ff681e064f4553ad83289c36d999ddc88) | `` terraform-providers.aviatrix: 3.2.0 -> 3.2.1 ``                                                   |
| [`68778799`](https://github.com/NixOS/nixpkgs/commit/68778799f10dceca319f72484e9781499003aaa2) | `` terraform-providers.gitlab: 17.5.0 -> 17.6.1 ``                                                   |
| [`9279cc08`](https://github.com/NixOS/nixpkgs/commit/9279cc088120c4800d81ccd9720acaae97c00d7a) | `` terraform-providers.google-beta: 6.12.0 -> 6.14.1 ``                                              |
| [`231d8616`](https://github.com/NixOS/nixpkgs/commit/231d8616f58012c2bd37ea4b4e335c52f9ff6991) | `` terraform-providers.datadog: 3.49.0 -> 3.50.0 ``                                                  |
| [`25c17e5d`](https://github.com/NixOS/nixpkgs/commit/25c17e5dc2ae5dec25396045767b08257fbe2e22) | `` terraform-providers.aiven: 4.30.0 -> 4.31.0 ``                                                    |
| [`22c582c9`](https://github.com/NixOS/nixpkgs/commit/22c582c91d1553f8aaae4e105186d520d6ddfd4d) | `` terraform-providers.grafana: 3.14.1 -> 3.15.3 ``                                                  |
| [`f03e79eb`](https://github.com/NixOS/nixpkgs/commit/f03e79ebd9c6e52d49cd6e365942ee043beee3ac) | `` ananicy-cpp: fix build with llvm_19 ``                                                            |
| [`9a1f8947`](https://github.com/NixOS/nixpkgs/commit/9a1f8947df4d6a0357206e26c111aee38f215483) | `` ananicy-cpp: unvendor mtabs upstream patch ``                                                     |
| [`4abac055`](https://github.com/NixOS/nixpkgs/commit/4abac0552efd65dd24401a8aae0d587704d4837f) | `` mixxx: 2.4.2 -> 2.5.0 (#368403) ``                                                                |
| [`3008b705`](https://github.com/NixOS/nixpkgs/commit/3008b7059c459ee070756d7f69d699416970a88b) | `` syslinux: sort patches ``                                                                         |
| [`7e5045fb`](https://github.com/NixOS/nixpkgs/commit/7e5045fbd87b344a698cf5d1baf71dcd8f297e4e) | `` syslinux: get gcc10 patch from Arch Linux ``                                                      |
| [`e67f08d4`](https://github.com/NixOS/nixpkgs/commit/e67f08d4105aa01dbe9e65bde294da8ab53ce8c0) | `` syslinux: migrate to `fetchpatch` and update hashes ``                                            |
| [`728ef7e2`](https://github.com/NixOS/nixpkgs/commit/728ef7e277a3eb58947f459263222d7a70f9e791) | `` syslinux: get Debian patches from Arch Linux as well ``                                           |
| [`2cbbfdb3`](https://github.com/NixOS/nixpkgs/commit/2cbbfdb316266f706f2526f7ab2b9b3dfc231e1f) | `` syslinux: migrate Arch Linux patches to new home ``                                               |
| [`204dc201`](https://github.com/NixOS/nixpkgs/commit/204dc2012100ccc9c52150226f542a6a4ab25f3f) | `` syslinux: fix incompatible pointer type for `setjmp` and `longjmp` ``                             |
| [`671d1c62`](https://github.com/NixOS/nixpkgs/commit/671d1c62e9ce323157163afc52b964b9f0fb020b) | `` syslinux: fix `data_area.size` type ``                                                            |
| [`2c0af53c`](https://github.com/NixOS/nixpkgs/commit/2c0af53ccaad810998a72c24c085ec644397dbfe) | `` terraform-providers.utils: 1.26.0 -> 1.28.0 ``                                                    |
| [`bb9f72da`](https://github.com/NixOS/nixpkgs/commit/bb9f72da776df7311a6ceca83ad9480e9dee0b24) | `` opentofu: 1.8.7 -> 1.8.8 ``                                                                       |
| [`e0e8116c`](https://github.com/NixOS/nixpkgs/commit/e0e8116c1857d8f66462eff7673bfcc6d0143627) | `` vesktop: fix crashing when settings.json or state.json are read-only (#368221) ``                 |
| [`a3464a42`](https://github.com/NixOS/nixpkgs/commit/a3464a420c5fe6694f7c16f8c3206ce2a97d86fb) | `` reiser4progs: mark as broken ``                                                                   |
| [`c22f1378`](https://github.com/NixOS/nixpkgs/commit/c22f13788f22ce308ee9ca40928c0efa5c529a08) | `` {libsForQt5,kdePackages}.{partitionmanager,kpmcore}: drop ReiserFS support ``                     |
| [`44949983`](https://github.com/NixOS/nixpkgs/commit/4494998307a50f54e0f1917c4698158072bbb2d8) | `` lnd: 0.18.3 -> 0.18.4 ``                                                                          |
| [`2d74deb1`](https://github.com/NixOS/nixpkgs/commit/2d74deb1409a28a20ad2a585cbce032fc04cfd53) | `` repren: 1.0.1 -> 1.0.2 ``                                                                         |
| [`93a00140`](https://github.com/NixOS/nixpkgs/commit/93a001404c028af867e133f0f9e3762195f5bd6b) | `` ladybird: 0-unstable-2024-11-21 -> 0-unstable-2024-12-23 ``                                       |
| [`bf740322`](https://github.com/NixOS/nixpkgs/commit/bf740322a7699bf579af3527e748edf2d49190ed) | `` mathematica: fix `sort` predicate stability ``                                                    |
| [`9e9e09cb`](https://github.com/NixOS/nixpkgs/commit/9e9e09cb952df3ba7a78f03fea15694e4c7d0c74) | `` typstyle: 0.12.13 -> 0.12.14 ``                                                                   |
| [`ef6ac2dd`](https://github.com/NixOS/nixpkgs/commit/ef6ac2dd6e6fe0f800d008fd9e314226617fb96a) | `` coqPackages.metaFetch: fix `sort` predicate stability ``                                          |
| [`403dfb7c`](https://github.com/NixOS/nixpkgs/commit/403dfb7c93a0aab6b2f8912ab613504725ef8e83) | `` nixos/ddclient: fix missing iproute2 ``                                                           |
| [`a69a7908`](https://github.com/NixOS/nixpkgs/commit/a69a7908ce1764f2c13448c60363c2627d131611) | `` python3Packages.tpm2-pytss: fixup revision in tests ``                                            |
| [`2077f59b`](https://github.com/NixOS/nixpkgs/commit/2077f59bd23d94a5c19047158383b83236898781) | `` python312Packages.oslo-serialization: 5.5.0 -> 5.6.0 ``                                           |
| [`b9ce1f48`](https://github.com/NixOS/nixpkgs/commit/b9ce1f483ffdc0402c54da2ad7ebc080d0bbd1e9) | `` plow: fix plow.passthru.tests ``                                                                  |
| [`7a485e47`](https://github.com/NixOS/nixpkgs/commit/7a485e4780d8ec591f8ef9f4a1257ca702076ecf) | `` nixos/ddclient: update defaults for usev4/6 ``                                                    |
| [`c510ae18`](https://github.com/NixOS/nixpkgs/commit/c510ae1821d75679ca3c25855486ccd1e061f864) | `` elixir: modify Elixir license to Apache 2.0 ``                                                    |
| [`3610091a`](https://github.com/NixOS/nixpkgs/commit/3610091aebc69629498d1fa13f48cb9a40be026a) | `` lychee: 0.17.0 -> 0.18.0 ``                                                                       |
| [`988610e0`](https://github.com/NixOS/nixpkgs/commit/988610e0b65a1ce23d31df9628a3a85fb6ec9a46) | `` python312Packages.latexify-py: 0.4.3-post1 -> 0.4.4 ``                                            |
| [`300e97ba`](https://github.com/NixOS/nixpkgs/commit/300e97baaf10690b21e963e98638987000f63862) | `` testers.hasPkgConfigModules: Simplify derivation name, use package name ``                        |
| [`50c4f70d`](https://github.com/NixOS/nixpkgs/commit/50c4f70db16b5a3215c3a10caf2c27ea73ff0ab8) | `` testers.hasPkgConfigModules: Shorten derivation name ``                                           |
| [`8e60cfc2`](https://github.com/NixOS/nixpkgs/commit/8e60cfc23b856139aa3d7239761f7c3b4d683038) | `` nextcloud30Packages: update ``                                                                    |
| [`b23171b4`](https://github.com/NixOS/nixpkgs/commit/b23171b4d826cbcc59deb5a90c7c02274c0bad05) | `` nextcloud29Packages: update ``                                                                    |
| [`245ff4f7`](https://github.com/NixOS/nixpkgs/commit/245ff4f757e19bb360189a9df48049315e16bbe4) | `` nextcloud28Packages: update ``                                                                    |
| [`b19b16be`](https://github.com/NixOS/nixpkgs/commit/b19b16be96929dea99c12705e233a8dc4087a376) | `` nixos/stalwart-mail: Add `dataDir` option ``                                                      |
| [`1d490aef`](https://github.com/NixOS/nixpkgs/commit/1d490aeff094b67c41e5e85cb0484e4b4629bed0) | `` python3Packages.posthog: fix build ``                                                             |
| [`9d062b44`](https://github.com/NixOS/nixpkgs/commit/9d062b44e3541265219b0b0c1fe5c69c5c43b39a) | `` signaturepdf: 1.7.1 -> 1.7.2 ``                                                                   |
| [`e187a6e9`](https://github.com/NixOS/nixpkgs/commit/e187a6e9f53aa5096083fed0dce051c2d3e3b498) | `` next-ls: unpin erlang and elixir ``                                                               |
| [`431238ad`](https://github.com/NixOS/nixpkgs/commit/431238adcc6e6ef70cc15413f2a9186659e1a4ed) | `` ex_doc: pin to elixir 1.17 ``                                                                     |
| [`280e6f78`](https://github.com/NixOS/nixpkgs/commit/280e6f784555bf7278e9d0538f28982d2c1875c5) | `` livebook: move to by-name ``                                                                      |
| [`3ccfb456`](https://github.com/NixOS/nixpkgs/commit/3ccfb4568da8a7208aefece9160138028680c9f4) | `` elixir: update default to 1.18 ``                                                                 |
| [`e5f2ebf6`](https://github.com/NixOS/nixpkgs/commit/e5f2ebf6d3350d367bc130fc53d60e8914120b1e) | `` nixos/zfs-replication: add package option ``                                                      |
| [`05886dea`](https://github.com/NixOS/nixpkgs/commit/05886deae14230a7c300f80c3bca0bfb9f93999a) | `` python312Packages.yaramod: 4.0.1 -> 4.0.2 ``                                                      |
| [`9e08e084`](https://github.com/NixOS/nixpkgs/commit/9e08e0842f15c7ccad229ae74d573412933edbf3) | `` python312Packages.bleak-esphome: 1.1.0 -> 1.1.1 ``                                                |
| [`a0bb3513`](https://github.com/NixOS/nixpkgs/commit/a0bb3513ac7c7500a3c81b86667cccfa5f3260f7) | `` mobilizon: pin to erlang 26 ``                                                                    |
| [`aba7516e`](https://github.com/NixOS/nixpkgs/commit/aba7516e98cb45946d326d77f4f92cc6aeea1470) | `` python312Packages.tempest: 41.0.0 -> 42.0.0 ``                                                    |
| [`3bae6691`](https://github.com/NixOS/nixpkgs/commit/3bae66911fe6ea397348eaefc3c83ca9015d70cb) | `` erlang_24: remove as unmaintained ``                                                              |
| [`46e88039`](https://github.com/NixOS/nixpkgs/commit/46e880399accc51fb41ffe722b59b45f2f78af63) | `` python312Packages.gehomesdk: 0.5.30 -> 0.5.41 ``                                                  |
| [`a674b86e`](https://github.com/NixOS/nixpkgs/commit/a674b86e4c57c9e2cd54bab713e593550c05f8e7) | `` python312Packages.cliff: 4.7.0 -> 4.8.0 ``                                                        |
| [`f46e0929`](https://github.com/NixOS/nixpkgs/commit/f46e0929766410c958372bf94de94f55da800979) | `` ejsonkms: 0.2.2 -> 0.2.3 ``                                                                       |
| [`52e018f4`](https://github.com/NixOS/nixpkgs/commit/52e018f4f87362737c2d6ecc9d1264c6d2f9d84e) | `` ankama-launcher: 3.12.27 -> 3.12.28 ``                                                            |
| [`e4cc105d`](https://github.com/NixOS/nixpkgs/commit/e4cc105d2a5cf6dba4ecd9f05a4144b74b60bfbc) | `` python312Packages.total-connect-client: 2024.12 -> 2024.12.1 ``                                   |
| [`c5fbefec`](https://github.com/NixOS/nixpkgs/commit/c5fbefeceabd1415f93e90df166df155be59f070) | `` proxsuite: fix build with clang ``                                                                |
| [`69a8aba1`](https://github.com/NixOS/nixpkgs/commit/69a8aba1130b9475797f76a1cba01bfc77889568) | `` nixos/opensmtpd: run nixfmt as requested by ci ``                                                 |
| [`fb4ff06a`](https://github.com/NixOS/nixpkgs/commit/fb4ff06a4be7a2b39a229bf1d1068804c18becc2) | `` fix opensmtpd's sendmail, add relevant test ``                                                    |
| [`c340fd89`](https://github.com/NixOS/nixpkgs/commit/c340fd898c78d96ff69781af4388318c44537cf2) | `` nixos/opensmtpd: fix opensmtpd-rspamd test ``                                                     |
| [`42c26346`](https://github.com/NixOS/nixpkgs/commit/42c2634653c1ca5dca48ccb51a6c1949212ca6ff) | `` nixos/opensmtpd: fix opensmtpd test ``                                                            |
| [`765d1e55`](https://github.com/NixOS/nixpkgs/commit/765d1e5541afa40d537eb2b7fbca3cfde9e59e2b) | `` deepin.deepin-terminal: 6.0.15 -> 6.0.17 ``                                                       |
| [`6e995644`](https://github.com/NixOS/nixpkgs/commit/6e9956444b58ba20be866abad7b45d71859b9f6b) | `` python312Packages.oracledb: 2.4.1 -> 2.5.1 ``                                                     |
| [`f5245d57`](https://github.com/NixOS/nixpkgs/commit/f5245d579e853b6c2e0b42a3ed71690a7a4febbf) | `` python312Packages.oslo-i18n: 6.4.0 -> 6.5.0 ``                                                    |
| [`21ed640c`](https://github.com/NixOS/nixpkgs/commit/21ed640cbe5be76689f87604aeab26bf5ff487db) | `` akkoma: use erlang 26 ``                                                                          |
| [`34ce9b5a`](https://github.com/NixOS/nixpkgs/commit/34ce9b5ae2200098809de78416883554f39b5e67) | `` python311Packages.pontos: 24.12.3 -> 24.12.4 ``                                                   |
| [`41f9fd5d`](https://github.com/NixOS/nixpkgs/commit/41f9fd5da8b4e6b97c7eb9400acd5aa66a92a63d) | `` vimPlugins.mason-nvim-dap-nvim: init at 2024-08-04 ``                                             |
| [`834fa310`](https://github.com/NixOS/nixpkgs/commit/834fa310e1d1378ceb08eca03afd307c9f844792) | `` vimPlugins.mason-null-ls-nvim: init at 2024-04-09 ``                                              |
| [`be86a5f8`](https://github.com/NixOS/nixpkgs/commit/be86a5f876b12fa1f0652d9a503aa3f30d92621e) | `` python312Packages.tencentcloud-sdk-python: 3.0.1288 -> 3.0.1289 ``                                |
| [`173f27f7`](https://github.com/NixOS/nixpkgs/commit/173f27f7d9645a4415f686c84b41a7c09e54c6b1) | `` vimPlugins.astroui: init at 2024-12-23 ``                                                         |
| [`d4797eb1`](https://github.com/NixOS/nixpkgs/commit/d4797eb1104b3043739619fe68df5ea2c8d42483) | `` vimPlugins.astrolsp: init at 2024-12-23 ``                                                        |
| [`79795a57`](https://github.com/NixOS/nixpkgs/commit/79795a57979b7bf213e624f6661855fa651cf1a6) | `` vimPlugins.astrocore: init at 2024-12-23 ``                                                       |
| [`ab2a3661`](https://github.com/NixOS/nixpkgs/commit/ab2a3661acafa4e135903780967b5a42eb30a0d1) | `` python312Packages.pyiceberg: enable distutils patch on python3.12 ``                              |
| [`3d2a98c9`](https://github.com/NixOS/nixpkgs/commit/3d2a98c916f58325f92b83df4f4dab4c54b569a8) | `` asusd: add release note about breaking changes ``                                                 |
| [`d29066d0`](https://github.com/NixOS/nixpkgs/commit/d29066d0f3d557b3e21304cd803c3cab27c54c85) | `` ansible: 2.17.6 -> 2.18.1 ``                                                                      |
| [`6c63c2c4`](https://github.com/NixOS/nixpkgs/commit/6c63c2c49a1a01fd8dbcf361f45b7e27950d70d9) | `` python312Packages.ansible: 10.4.0 -> 11.1.0 ``                                                    |
| [`68b821ff`](https://github.com/NixOS/nixpkgs/commit/68b821ffc120c3975f2893b1069f1deeed58ee23) | `` monado: gate tracing support behind argument ``                                                   |
| [`865188fe`](https://github.com/NixOS/nixpkgs/commit/865188fefd30b48de3ee489bb45f9cac7d449a4b) | `` python312Packages.oslo-concurrency: 6.1.0 -> 6.2.0 ``                                             |
| [`190d01cf`](https://github.com/NixOS/nixpkgs/commit/190d01cf919504dec5518ed9b5561e33be051c8a) | `` python312Packages.pysigma-backend-splunk: 1.1.0 -> 1.1.2 ``                                       |
| [`754abe63`](https://github.com/NixOS/nixpkgs/commit/754abe634e8fe660887e14a6cecada7a61ce2541) | `` vhdl-ls: 0.83.0 -> 0.83.1 ``                                                                      |
| [`a1cfcf8c`](https://github.com/NixOS/nixpkgs/commit/a1cfcf8cf18c9094d71653ca128d8d88a0b20cae) | `` vdrPlugins.softhddevice: 2.4.0 -> 2.4.1 ``                                                        |
| [`1337b7d7`](https://github.com/NixOS/nixpkgs/commit/1337b7d77741c8bd8694b2e87544cd102f746d08) | `` mesa: fix broken vaapi/vdpau symlinks ``                                                          |
| [`45cd7cf4`](https://github.com/NixOS/nixpkgs/commit/45cd7cf4b9aea349a289320557ed41e3fd857127) | `` monero-cli: fix build issue with GCC14 ``                                                         |
| [`5b8caa6c`](https://github.com/NixOS/nixpkgs/commit/5b8caa6cc6366868bb10c61d1a8dc358197b66dd) | `` gitstatus: fix darwin build ``                                                                    |
| [`2e86b37d`](https://github.com/NixOS/nixpkgs/commit/2e86b37d72d43e1fcee1de76f3978a889f2690cc) | `` yarnConfigHook: fix darwin permissions ``                                                         |
| [`57b90e89`](https://github.com/NixOS/nixpkgs/commit/57b90e89385e998ad8ae13c42aa618b8f0c8be48) | `` python312Packages.onnxmltools: 1.12.0 -> 1.13 ``                                                  |
| [`0bc5b5d1`](https://github.com/NixOS/nixpkgs/commit/0bc5b5d1bb374b73e9fd133c6f0adc5cc95430c3) | `` keypunch: 4.0 -> 5.0 ``                                                                           |
| [`b22aa24f`](https://github.com/NixOS/nixpkgs/commit/b22aa24f13ec3dbe4dc4f42f07f6cde631d96cb2) | `` slskd: 0.22.0 -> 0.22.1 (#368181) ``                                                              |
| [`b1d78097`](https://github.com/NixOS/nixpkgs/commit/b1d78097a2052388f5a18e6d163d64c3a0551565) | `` fastfetch: disable flashfetch binary by default ``                                                |
| [`7344c032`](https://github.com/NixOS/nixpkgs/commit/7344c032b107c6bd1923e9360d6eb813e69e0451) | `` fastfetch: 2.32.1 -> 2.33.0 ``                                                                    |
| [`46717f45`](https://github.com/NixOS/nixpkgs/commit/46717f4547bb1e9411dda473d152a2d2d5461a39) | `` python312Packages.weaviate-client: disabled failed test ``                                        |
| [`96380f22`](https://github.com/NixOS/nixpkgs/commit/96380f22af0380741f20db1e5ba43c76fdd5d267) | `` litestar: 2.12.1 -> 2.13.0 ``                                                                     |
| [`e0edb71e`](https://github.com/NixOS/nixpkgs/commit/e0edb71e2cabd5d627d801a275f9efc6c1d57383) | `` python312Packages.polyfactory: 2.18.1 -> 2.18.1-unstable-2024-12-22 ``                            |
| [`ec058a15`](https://github.com/NixOS/nixpkgs/commit/ec058a1565c55ffa338e1b9bbc853389b3827c9f) | `` python312Packages.litestar-htmx: init at 0.4.1 ``                                                 |
| [`2a09cdf7`](https://github.com/NixOS/nixpkgs/commit/2a09cdf753cf411f7e34d8775900441ad35fd624) | `` lua-language-server: use nixpkgs fmt ``                                                           |
| [`8cdd06a3`](https://github.com/NixOS/nixpkgs/commit/8cdd06a395654696c4b06d0d713c9e33291e0493) | `` gopeed: 1.6.4 -> 1.6.5 ``                                                                         |
| [`d37cf825`](https://github.com/NixOS/nixpkgs/commit/d37cf825ee09bf402af7b2038987c458d5c5e50f) | `` python312Packages.llama-cloud: 0.1.6 -> 0.1.7 ``                                                  |
| [`32f71416`](https://github.com/NixOS/nixpkgs/commit/32f71416563fd8c8d1bcce4a7085c5007a682ef2) | `` linux/hardened/patches/6.6: v6.6.66-hardened1 -> v6.6.67-hardened1 ``                             |
| [`525f1404`](https://github.com/NixOS/nixpkgs/commit/525f140471cbe6cafe3a481288ee58987ab50c6e) | `` linux/hardened/patches/6.12: v6.12.5-hardened1 -> v6.12.6-hardened1 ``                            |
| [`438b9086`](https://github.com/NixOS/nixpkgs/commit/438b90863b44f22d55155af5b92064bc4a5532f9) | `` linux/hardened/patches/6.1: v6.1.120-hardened1 -> v6.1.121-hardened1 ``                           |
| [`11aa7fa5`](https://github.com/NixOS/nixpkgs/commit/11aa7fa5b571c3ee39419294c805a42a521af872) | `` linux/hardened/patches/5.4: v5.4.287-hardened1 -> v5.4.288-hardened1 ``                           |
| [`e3d798d1`](https://github.com/NixOS/nixpkgs/commit/e3d798d1017addd6c006bf811886660229dce812) | `` linux/hardened/patches/5.15: v5.15.174-hardened1 -> v5.15.175-hardened1 ``                        |
| [`f04d7668`](https://github.com/NixOS/nixpkgs/commit/f04d7668946332612eb7e4b5d4427f878de10242) | `` linux/hardened/patches/5.10: v5.10.231-hardened1 -> v5.10.232-hardened1 ``                        |
| [`743b310b`](https://github.com/NixOS/nixpkgs/commit/743b310b329063653805cf2191f27bb2feb792c8) | `` linux/{common-config,hardened-config}: restore DRM_PANIC_SCREEN_QR_CODE, RUST, SCHED_CLASS_EXT `` |
| [`220d39fe`](https://github.com/NixOS/nixpkgs/commit/220d39fe0a80ae93287b5de1c68ff5e85c2a8f06) | `` python312Packages.mkdocs-awesome-pages-plugin: 2.9.3 -> 2.10.1 ``                                 |
| [`1cf85a93`](https://github.com/NixOS/nixpkgs/commit/1cf85a93527703f4f268423ec1bea9ea5f54f825) | `` postgresqlPackages.pgrouting: 3.7.0 -> 3.7.1 ``                                                   |
| [`65216ff4`](https://github.com/NixOS/nixpkgs/commit/65216ff4f3fac48ee4f37ce6f7ff6d10edca7a6d) | `` wootility: add returntoreality to maintainers ``                                                  |
| [`5c104311`](https://github.com/NixOS/nixpkgs/commit/5c104311486f4a5ee51595f6656d6457abda081b) | `` wootility: 4.6.21 -> 4.7.2 ``                                                                     |
| [`21ccd4ba`](https://github.com/NixOS/nixpkgs/commit/21ccd4badf052dbebf6b04ceb463585425ef28f5) | `` wooting-udev-rules: add returntoreality to maintainers ``                                         |
| [`b325158b`](https://github.com/NixOS/nixpkgs/commit/b325158bc2a6a442ba03fa7c3cae428d430d23ab) | `` wooting: update module description ``                                                             |