### PR TITLE
chore(flake/hyprland): `2b01a5bc` -> `1989b004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1735394862,
-        "narHash": "sha256-6/4VTVdtg8/DJUy/FsOk+bSoqAeYwZGFnCexmNaPWk0=",
+        "lastModified": 1735585949,
+        "narHash": "sha256-0nT9kNyyQlhpMHakQLyINZoJAjRAui4WsbxrRev6Gwc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "2b01a5bcf62956a5d641a3367edcd35e103edfcd",
+        "rev": "1989b0049f7fb714a2417dfb14d6b4f3d2a079d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| [`1989b004`](https://github.com/hyprwm/Hyprland/commit/1989b0049f7fb714a2417dfb14d6b4f3d2a079d3) | `` hyprpm: add glaze dependency FetchContent fallback (#8899) ``                      |
| [`9f933da1`](https://github.com/hyprwm/Hyprland/commit/9f933da1c502989cadf7696971aa376d65847b95) | `` renderer: fix oversized blur precalcs not blurring at all ``                       |
| [`af301312`](https://github.com/hyprwm/Hyprland/commit/af301312d5b9d69a39fd0a7584d2891f34d40430) | `` core: fix custom resolutions (#8897) ``                                            |
| [`8c14c2a5`](https://github.com/hyprwm/Hyprland/commit/8c14c2a5f472cf3d361d3cbb90ee7d2d455aae08) | `` ctm: disable fade animation by default on nvidia ``                                |
| [`cb211d83`](https://github.com/hyprwm/Hyprland/commit/cb211d83f68542e9fbf7567d57bdf528286cbf7e) | `` internal: few small monitor improvements (#8890) ``                                |
| [`fde569db`](https://github.com/hyprwm/Hyprland/commit/fde569db6519b613369c863d192c67dedb386910) | `` master: replace always_center_master with slave_count_for_center_master (#8871) `` |
| [`5b37d539`](https://github.com/hyprwm/Hyprland/commit/5b37d53992f3f9bfd7f5483a85f99adf7ac104f3) | `` hyprpm: add an option to force reload all plugins (#8883) ``                       |
| [`deb077c3`](https://github.com/hyprwm/Hyprland/commit/deb077c34653eab251bfe71970bb5987913e7c6d) | `` ctm: add an internal fade animation to ctm transitions ``                          |
| [`3f40d6d9`](https://github.com/hyprwm/Hyprland/commit/3f40d6d9361d0c5fec558b7549e58203fbe5cbd7) | `` pass: scale blur region in ::render ``                                             |
| [`a364e804`](https://github.com/hyprwm/Hyprland/commit/a364e80425b5993d8f2162963a6030fb3c3cb72e) | `` snap: give edge snapping precedence over corner snapping (#8873) ``                |