### PR TITLE
chore(flake/nixpkgs): `634fd468` -> `88195a94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735291276,
-        "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "634fd46801442d760e09493a794c4f15db2d0cbb",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`11bbeb48`](https://github.com/NixOS/nixpkgs/commit/11bbeb48fb07a6d67c36303641fdfd614f7fda18) | `` pylyzer: 0.0.75 -> 0.0.76 ``                                                             |
| [`42e57dec`](https://github.com/NixOS/nixpkgs/commit/42e57decdf4da8a2ba57c690b56a9771900a2b2d) | `` paper-clip: fix compilation error caused by glib ``                                      |
| [`961b9e65`](https://github.com/NixOS/nixpkgs/commit/961b9e65e63209e559b054afbe64bd62820033f5) | `` catimg: fix compilation with gcc-14 ``                                                   |
| [`1186e7e8`](https://github.com/NixOS/nixpkgs/commit/1186e7e8ddbc603f835a72a43dd2032d9f872fc6) | `` python312Packages.picos: 2.0 -> 2.5 ``                                                   |
| [`24543ec1`](https://github.com/NixOS/nixpkgs/commit/24543ec1cd4600143b18a1d177f171980b7e7578) | `` gpufetch: init at 0.25 ``                                                                |
| [`716c9419`](https://github.com/NixOS/nixpkgs/commit/716c9419b082aed4560232b277f8be6250858926) | `` ghostty: add nixos tests, add build options, fix x11 backend (#368726) ``                |
| [`8a3157d3`](https://github.com/NixOS/nixpkgs/commit/8a3157d3b9ef0b1d4eae1e2cb57d40b4762476f2) | `` mympd: 19.0.1 -> 19.0.2 ``                                                               |
| [`33b71747`](https://github.com/NixOS/nixpkgs/commit/33b717475894bfd8fc5448c4830e25582efaa6b0) | `` peakperf: init at 1.17-unstable-2024-10-07 ``                                            |
| [`a2e6dae6`](https://github.com/NixOS/nixpkgs/commit/a2e6dae665625c716f6d346d25dc935e07e9776d) | `` python312Packages.mypy-boto3-securityhub: 1.35.72 -> 1.35.88 ``                          |
| [`abc4331f`](https://github.com/NixOS/nixpkgs/commit/abc4331f5f2710cd91818e1f4cbafba792eef6b4) | `` python312Packages.mypy-boto3-rds: 1.35.82 -> 1.35.89 ``                                  |
| [`ccb42677`](https://github.com/NixOS/nixpkgs/commit/ccb42677912a45c78c7ed6850aa454f378883409) | `` python312Packages.mypy-boto3-network-firewall: 1.35.52 -> 1.35.88 ``                     |
| [`61c9c48c`](https://github.com/NixOS/nixpkgs/commit/61c9c48cba321725e19429747d4cdc33975e163f) | `` python312Packages.mypy-boto3-ecr-public: 1.35.87 -> 1.35.90 ``                           |
| [`9cefdf67`](https://github.com/NixOS/nixpkgs/commit/9cefdf6752c014c5c75f8365986a02bcac6653d3) | `` python312Packages.mypy-boto3-ecr: 1.35.87 -> 1.35.90 ``                                  |
| [`33a28d82`](https://github.com/NixOS/nixpkgs/commit/33a28d82f0f17344b1816f8036a290b81d668263) | `` arc_unpacker: fix build ``                                                               |
| [`8b4fd3e8`](https://github.com/NixOS/nixpkgs/commit/8b4fd3e8d61280c3d690723ca3a8ee2dd4556e56) | `` movim: make mainProgram name match ``                                                    |
| [`180c9531`](https://github.com/NixOS/nixpkgs/commit/180c953138c3371620197dee79cee3afd6c0ae1c) | `` nixos/movim: rm logs if found ``                                                         |
| [`0d59a592`](https://github.com/NixOS/nixpkgs/commit/0d59a5928e712e3a87c7c0cfef7fbb40f0e53975) | `` optionally add group to nginx user ``                                                    |
| [`22c7e685`](https://github.com/NixOS/nixpkgs/commit/22c7e68534e76001fffea10181a3d63fb84c2e12) | `` syntax hints for tree-sitter ``                                                          |
| [`c15c466d`](https://github.com/NixOS/nixpkgs/commit/c15c466d29f4e80bd04ad5c679e0c081f66fcad2) | `` typo in script name ``                                                                   |
| [`431afe72`](https://github.com/NixOS/nixpkgs/commit/431afe7289d8d6c233c21f08222bb202abb743a8) | `` use mkDefaults for Nginx config ``                                                       |
| [`2e5268e2`](https://github.com/NixOS/nixpkgs/commit/2e5268e2a5d559b03f293f96a6dce5f4b16de8fa) | `` use movim’s database user ``                                                             |
| [`af5356b7`](https://github.com/NixOS/nixpkgs/commit/af5356b74c2e04eceba7dec1a62a1a8b1d9a215a) | `` gzdoom: 4.13.2 -> 4.14.0 ``                                                              |
| [`5f3fe888`](https://github.com/NixOS/nixpkgs/commit/5f3fe888943c71e9c04a862d3377c288bbbc8d69) | `` oscavmgr: add version test ``                                                            |
| [`5df29533`](https://github.com/NixOS/nixpkgs/commit/5df295339a9d14cc52c6b5a9b532c5d79ac4ff4d) | `` jujutsu: update owner; change from rev to tag ``                                         |
| [`ca90631c`](https://github.com/NixOS/nixpkgs/commit/ca90631cfb213290eb73fb14b054465d7d3b77d2) | `` python312Packages.python-telegram-bot: 21.7 -> 21.9 (#368217) ``                         |
| [`cac0e6ea`](https://github.com/NixOS/nixpkgs/commit/cac0e6eaf4d98efc84fad2435f8386666b286e9f) | `` bilibili: 1.16.1-1 -> 1.16.1-2 ``                                                        |
| [`4579f217`](https://github.com/NixOS/nixpkgs/commit/4579f217834b2e5d67595f187506f3e4b4e7f3a0) | `` distant: init at 0.20.0 ``                                                               |
| [`e1c234e5`](https://github.com/NixOS/nixpkgs/commit/e1c234e5e2996b030a0fa9bfc686f9bd624d5336) | `` treewide: add updateScript to gnome circle packages (#367823) ``                         |
| [`15d38c4c`](https://github.com/NixOS/nixpkgs/commit/15d38c4c5fc2ea9af0228b6bd32543e786fb3dba) | `` netbird: 0.34.1 -> 0.35.1 ``                                                             |
| [`45326182`](https://github.com/NixOS/nixpkgs/commit/45326182fd9ee391fc470474340b5dd1c01894cf) | `` nextcloud-client: add libsysprof-capture to dependencies as asked by the build system `` |
| [`59156600`](https://github.com/NixOS/nixpkgs/commit/59156600340990e3081254cac40911d851618e19) | `` nextcloud-client: 3.14.3 -> 3.15.2 ``                                                    |
| [`a213da1d`](https://github.com/NixOS/nixpkgs/commit/a213da1d8bba75dc5b0c0677704c06d16acf1e79) | `` nextcloud-client: move to by-name, tweak ``                                              |
| [`4ec084e8`](https://github.com/NixOS/nixpkgs/commit/4ec084e858be97ee9f6f007dabaccecee4a78953) | `` sofia-sip: fix build with gcc-14 ``                                                      |
| [`1f4e626d`](https://github.com/NixOS/nixpkgs/commit/1f4e626d43b2c24247450548dec1c7c0d6078f31) | `` fittrackee: 0.8.10 -> 0.8.12 ``                                                          |
| [`e8ef3a06`](https://github.com/NixOS/nixpkgs/commit/e8ef3a063cd255e1fd5bb8baefbe28c0f1785df1) | `` libdbiDrivers: fix compile errors in tests, backport patches ``                          |
| [`7bd3a283`](https://github.com/NixOS/nixpkgs/commit/7bd3a283c0b7dc9720880f70575e6e98abe740e3) | `` plexRaw: 1.41.3.9292-bc7397402 -> 1.41.3.9314-a0bfb8370 ``                               |
| [`1d22a9aa`](https://github.com/NixOS/nixpkgs/commit/1d22a9aa5abc2b89cfb60e00b460697673cba4bc) | `` rockcraft: add passthru.tests.version ``                                                 |
| [`113a737f`](https://github.com/NixOS/nixpkgs/commit/113a737ffe638d625345c096b5a27004e76179a9) | `` djlint: 1.35.2 -> 1.36.4 ``                                                              |
| [`4a77d7b4`](https://github.com/NixOS/nixpkgs/commit/4a77d7b4a1cc73fdb0046cd3601fccb67ab920e0) | `` rockcraft: actually use sources for 1.7.0 ``                                             |
| [`4cdcd2ba`](https://github.com/NixOS/nixpkgs/commit/4cdcd2ba31f816844a9555d1149b85e17f4ffb12) | `` teams: create Android team ``                                                            |
| [`9f95a717`](https://github.com/NixOS/nixpkgs/commit/9f95a717f998f8019ecc79fba81c28edc04be126) | `` changedetection-io: 0.48.01 -> 0.48.05 ``                                                |
| [`41d96618`](https://github.com/NixOS/nixpkgs/commit/41d966187675330d0d768d4da08a46dfc6dd7763) | `` nextcloud-client: remove unneeded patch ``                                               |
| [`472ebeea`](https://github.com/NixOS/nixpkgs/commit/472ebeea015262497e9613edf80133f24ef5c24d) | `` home-assistant-custom-components.xiaomi_miot: 1.0.2 -> 1.0.7 ``                          |
| [`eec3624d`](https://github.com/NixOS/nixpkgs/commit/eec3624d22b3add7daea87c44e064109104292e5) | `` home-assistant-custom-components.xiaomi_gateway3: 4.0.7 -> 4.0.8 ``                      |
| [`4650173a`](https://github.com/NixOS/nixpkgs/commit/4650173a18cdaf55abb02bcab9d96cba734f4b75) | `` srtrelay: 1.1.0 -> 1.3.0 ``                                                              |
| [`4bb7bc77`](https://github.com/NixOS/nixpkgs/commit/4bb7bc77c98e4ddd355785b4875e4ac484383e62) | `` swiftformat: 0.47.10 -> 0.55.4 ``                                                        |
| [`98afe02b`](https://github.com/NixOS/nixpkgs/commit/98afe02bd1a33e6e56a668f152c73e776d9a2275) | `` stlink: patch incorrect calloc argument order ``                                         |
| [`1a571dc1`](https://github.com/NixOS/nixpkgs/commit/1a571dc10404d24517731d8905036745d6a30a43) | `` quartus-prime-lite: 23.1std.0.991 -> 23.1std.1.993 ``                                    |
| [`ce305ada`](https://github.com/NixOS/nixpkgs/commit/ce305adae501a27be8c2d28a4c588b57b5643f8e) | `` trufflehog: 3.87.0 -> 3.88.0 ``                                                          |
| [`34d48c3e`](https://github.com/NixOS/nixpkgs/commit/34d48c3e804feae4c451770f5d7b507b9df68b6b) | `` victoriametrics: 1.108.0 -> 1.108.1 ``                                                   |
| [`6d7746e3`](https://github.com/NixOS/nixpkgs/commit/6d7746e3f0e04adfdbdd5d8788ec475236d88af7) | `` vscode: 1.96.0 -> 1.96.2 ``                                                              |
| [`da08b71a`](https://github.com/NixOS/nixpkgs/commit/da08b71a8ba2e57657f6040d24771497d24641f2) | `` fdroidserver: 2.3.1 -> 2.3.4 ``                                                          |
| [`0887d1a0`](https://github.com/NixOS/nixpkgs/commit/0887d1a0fecb8b601ca25312bae59a4f09225c95) | `` openapi-python-client: 0.22.0 -> 0.23.0 ``                                               |
| [`a0d07c62`](https://github.com/NixOS/nixpkgs/commit/a0d07c62c4726506bb36b939b8a993c3d1d1b092) | `` xcodegen: init ``                                                                        |
| [`87f28863`](https://github.com/NixOS/nixpkgs/commit/87f28863841c9b7145c22846e5247b3085d797b7) | `` ocamlPackages.h2: init h2-lwt, h2-lwt-unix at 0.13.0 ``                                  |
| [`39b7652c`](https://github.com/NixOS/nixpkgs/commit/39b7652cf1b08cd012e7735d48c0cae95525f898) | `` uasm: mark as broken in darwin ``                                                        |
| [`3d3b0cfb`](https://github.com/NixOS/nixpkgs/commit/3d3b0cfb5549ff66c4c27677c80cde92c3d81e1f) | `` cuneiform: add patch for gcc 14 ``                                                       |
| [`b0cfb8ab`](https://github.com/NixOS/nixpkgs/commit/b0cfb8abd8cb59704439255f4c1d127f2d511e0f) | `` libdwg: remove ``                                                                        |
| [`33952e2d`](https://github.com/NixOS/nixpkgs/commit/33952e2d6587a06fc5afe4244414a322e7354310) | `` wivrn: remove unused libdwg dependency ``                                                |
| [`35b51fd1`](https://github.com/NixOS/nixpkgs/commit/35b51fd1a0505270874c7412c77edb3654ba8526) | `` bruno: disable telemetry ``                                                              |
| [`0cb7e95f`](https://github.com/NixOS/nixpkgs/commit/0cb7e95fcf0762aaf68cd41fb6ce52d9cde5f691) | `` grandperspective: remove `with lib;` ``                                                  |
| [`0a2c3846`](https://github.com/NixOS/nixpkgs/commit/0a2c38464e87cf085b23df27340f145d7d9a2b3c) | `` vimPlugins.nvim-treesitter: update grammars ``                                           |
| [`5059dc64`](https://github.com/NixOS/nixpkgs/commit/5059dc64cc8ab4a93e3d5cc9aa3af2b5f0d239c3) | `` vimPlugins: update on 2024-12-28 ``                                                      |
| [`c5ef1d68`](https://github.com/NixOS/nixpkgs/commit/c5ef1d68ae1e611e50efddf6cedb4fde703efa25) | `` x32edit,m32edit: 4.1 -> 4.3 ``                                                           |
| [`8324b900`](https://github.com/NixOS/nixpkgs/commit/8324b900910ff9a991bfc62269a5e8406dc76dca) | `` luaPackages: update on 2024-12-28 ``                                                     |
| [`f6fd5e95`](https://github.com/NixOS/nixpkgs/commit/f6fd5e95e1018a4947e6ff0325adb8999055e6c6) | `` vimPlugins.nvim-treesitter: update grammars ``                                           |
| [`f28f3f5f`](https://github.com/NixOS/nixpkgs/commit/f28f3f5fde375ac63bb63ce5ebc140080093e395) | `` vimPlugins: update on 2024-12-24 ``                                                      |
| [`7da04665`](https://github.com/NixOS/nixpkgs/commit/7da04665e33539636320081cc0ad2c15e8567e63) | `` luaPackages: update on 2024-12-24 ``                                                     |
| [`75a7c850`](https://github.com/NixOS/nixpkgs/commit/75a7c8507ad53484a1dfff8582a7b72f56a8ce0c) | `` orbiton: modernize ``                                                                    |
| [`ce0e60c0`](https://github.com/NixOS/nixpkgs/commit/ce0e60c0ae841437bba1a2119e6dd9c32fd6ead0) | `` cargo-semver-checks: refactor ``                                                         |
| [`64674918`](https://github.com/NixOS/nixpkgs/commit/64674918d88d19783d820674681c03f8ad846daf) | `` cargo-semver-checks: 0.34.0 -> 0.38.0 ``                                                 |
| [`7f6c88d5`](https://github.com/NixOS/nixpkgs/commit/7f6c88d5ad777bbcd501e9283f0e6711382dc7bb) | `` phpunit: 11.5.1 -> 11.5.2 ``                                                             |
| [`d1437e56`](https://github.com/NixOS/nixpkgs/commit/d1437e561b30d6679e76ba23221e523872592c12) | `` cargo-show-asm: 0.2.43 -> 0.2.45 ``                                                      |
| [`37302163`](https://github.com/NixOS/nixpkgs/commit/37302163ed7384d444053e30cfd2650b9bc1e07f) | `` rl-2411: add an entry for the new kmonad module ``                                       |
| [`4557afb6`](https://github.com/NixOS/nixpkgs/commit/4557afb6895fd97e56be14f79ba25cc070ddfd12) | `` pcmanfm: fixup build with gcc14 ``                                                       |
| [`13f1e8df`](https://github.com/NixOS/nixpkgs/commit/13f1e8df945ea243e972cd95779271dc27ee5778) | `` pik: 0.12.0 -> 0.13.0 ``                                                                 |
| [`8d16a352`](https://github.com/NixOS/nixpkgs/commit/8d16a352a956e34427c41e7e53ec9effae353244) | `` nchat: 5.3.5 -> 5.4.2 ``                                                                 |
| [`0bfb93d2`](https://github.com/NixOS/nixpkgs/commit/0bfb93d2c17a9fea260c1360c497543d5435f623) | `` home-assistant-custom-lovelace-modules.hourly-weather: 6.4.0 -> 6.5.0 ``                 |
| [`db5ca039`](https://github.com/NixOS/nixpkgs/commit/db5ca039e6feb69490e01e7e651edf83a6884b60) | `` maintainers: add adrian-gierakowski ``                                                   |
| [`bd0c705c`](https://github.com/NixOS/nixpkgs/commit/bd0c705c62c3df2091ff8d229446570099939ad1) | `` orbiton: 2.68.5 -> 2.68.6 ``                                                             |
| [`0cfcd3e1`](https://github.com/NixOS/nixpkgs/commit/0cfcd3e1c411c968b901604ded674d8ad42e0a05) | `` clusternet: 0.17.2 -> 0.17.3 ``                                                          |
| [`5f80781d`](https://github.com/NixOS/nixpkgs/commit/5f80781d03e6327f38da0fbf73f9e98be1cd4bee) | `` qpwgraph: 0.8.0 -> 0.8.1 ``                                                              |
| [`ca006099`](https://github.com/NixOS/nixpkgs/commit/ca006099ca0616a22ccd34df694aece580f39d44) | `` buildpack: 0.36.1 -> 0.36.2 ``                                                           |
| [`a4cfa02a`](https://github.com/NixOS/nixpkgs/commit/a4cfa02a403129dca848684c7f087bf128efe068) | `` ledger: fix build with boost 1.86 ``                                                     |
| [`64543f69`](https://github.com/NixOS/nixpkgs/commit/64543f6931c72d967bff3de3596d76992fc35e3f) | `` uasm: 2.56.2 -> 2.57 ``                                                                  |
| [`7ce186c2`](https://github.com/NixOS/nixpkgs/commit/7ce186c2bd89982034264e343c1da614a9ee92d1) | `` inspircd: 3.17.1 -> 3.18.0 ``                                                            |
| [`69c42fcc`](https://github.com/NixOS/nixpkgs/commit/69c42fccc0f388effc7f7e3483b51ea4e6302f93) | `` uasm: switch to gcc13Stdenv ``                                                           |
| [`c4c87945`](https://github.com/NixOS/nixpkgs/commit/c4c87945084042cbf9a6adccfe4f52183c1487fe) | `` libretro.mupen64plus: add patches for GCC14 ``                                           |
| [`8df5fbac`](https://github.com/NixOS/nixpkgs/commit/8df5fbacc7f896d01767107da6638abf15352c6b) | `` vdrPlugins.markad: 4.2.7 -> 4.2.8 ``                                                     |
| [`a49023bc`](https://github.com/NixOS/nixpkgs/commit/a49023bcb550bcd84e1fa8afcbe7aa8bc0850bf4) | `` perlPackages.NetIDNEncode: fix use of function removed in Perl 5.38.0 ``                 |
| [`a00e8271`](https://github.com/NixOS/nixpkgs/commit/a00e8271102e33bb7993a727544c02a568f2441d) | `` nixos/tests/networkmanager: test NM is started at boot ``                                |
| [`69b630d8`](https://github.com/NixOS/nixpkgs/commit/69b630d89352730abb90be82d448af1cb5cac190) | `` nixos/networkmanager: match upstream units Install sections ``                           |
| [`37ec46ac`](https://github.com/NixOS/nixpkgs/commit/37ec46ac40ac9016921d69fb3673473fd7a20c95) | `` pamtester: add autoreconfHook ``                                                         |
| [`7ddc9376`](https://github.com/NixOS/nixpkgs/commit/7ddc93760db96b435279060b253ba45932257c57) | `` proton-ge-bin: GE-Proton9-21 -> GE-Proton9-22 ``                                         |
| [`e2ff22d3`](https://github.com/NixOS/nixpkgs/commit/e2ff22d3d71b21ccf5bf4d24d9b6ac0f9dc87eab) | `` godini: init at 1.0.0 ``                                                                 |
| [`8b4146d9`](https://github.com/NixOS/nixpkgs/commit/8b4146d9857ec9b9e92d7f39643c651aefc86eb1) | `` treegen: init at 1.1.0 ``                                                                |