### PR TITLE
chore(flake/hyprland): `67e1e46f` -> `25add268`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1736279929,
-        "narHash": "sha256-F7e1z0rbCmvDLhbBuQ6Y/zzFYRBZXuSP1GrsterrdwU=",
+        "lastModified": 1736873552,
+        "narHash": "sha256-VByeYPOu3I0a5r5Nn45loSaEV8M9fmZrTByUdu9sjfY=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "67e1e46f9b6285ea260bc88844f85dec6b7d7d02",
+        "rev": "25add26881d7b98d2b80eb7a95d3aee0449b72b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                       |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
| [`25add268`](https://github.com/hyprwm/Hyprland/commit/25add26881d7b98d2b80eb7a95d3aee0449b72b9) | `` renderer: unload background texture if it's disabled ``                                    |
| [`f16f1704`](https://github.com/hyprwm/Hyprland/commit/f16f170433540d85cf672217bca2d64c6db9eb01) | `` protocols: immediately copy toplevel content when ignoreDamage set (#9049) ``              |
| [`a6b26371`](https://github.com/hyprwm/Hyprland/commit/a6b263713a2b862ed41362082e2147e081934077) | `` protocols: allow hyprland-toplevel-export to capture hidden windows (#9041) ``             |
| [`4f0f512c`](https://github.com/hyprwm/Hyprland/commit/4f0f512cab5a8052c80b365449b69b953a97e169) | `` protocols: do not capture cursor in toplevel without pointer focus (#9042) ``              |
| [`a3a74993`](https://github.com/hyprwm/Hyprland/commit/a3a74993173662c06025ca633faa68b5590e2c5b) | `` renderer: Do not set hdr metadata unless needed (#9014) ``                                 |
| [`b117fae3`](https://github.com/hyprwm/Hyprland/commit/b117fae3b493b9d5ac7ada3140cac555c3979dfd) | `` keybinds: fix movefocus fallback for special workspaces (#9040) ``                         |
| [`2671656a`](https://github.com/hyprwm/Hyprland/commit/2671656a75708452e9408a111e69e4436b6ad301) | `` helpers/Monitor.cpp: fix include path (#9039) ``                                           |
| [`2778aff0`](https://github.com/hyprwm/Hyprland/commit/2778aff08fba59a34b404751039d7acb6bfb3bdf) | `` animations: fix XWayland cursor glitch and refactor skill issues (#9033) ``                |
| [`9e4f90ae`](https://github.com/hyprwm/Hyprland/commit/9e4f90aedf2f51d3e7f3dbe5391cb193aa0bddf5) | `` animation: fixup adding animvars during ::tick (#9030) ``                                  |
| [`15dc024a`](https://github.com/hyprwm/Hyprland/commit/15dc024a398d35957ccfb50ddade5f456a1646b5) | `` keybinds: fix previous_per_monitor logic (#9010) ``                                        |
| [`3b85690a`](https://github.com/hyprwm/Hyprland/commit/3b85690aa6d9c14bb926692e25cc4480b85200ab) | `` config: add exec(-onec) with rules and execr(-once) (#8953) ``                             |
| [`cef09fbf`](https://github.com/hyprwm/Hyprland/commit/cef09fbfe6624d2133d81be863bd48bcfc5939d3) | `` animation: avoid crashes in ::tick() on mutations ``                                       |
| [`a8b568c6`](https://github.com/hyprwm/Hyprland/commit/a8b568c6c451cdce3c8d40ae010247be3f25728b) | `` core: Add render:allow_early_buffer_release to make buffer release configurable (#9019) `` |
| [`b5fb6110`](https://github.com/hyprwm/Hyprland/commit/b5fb6110ab1f75440b4b90d09f95d304d8c2080b) | `` core: Add a periodic donation request (#8981) ``                                           |
| [`da9252a2`](https://github.com/hyprwm/Hyprland/commit/da9252a23e69fc4d34beca73ebcc90b03af0ed2a) | `` keybinds: fix nullptr deref in forcekillactive (#9021) ``                                  |
| [`8475a8ef`](https://github.com/hyprwm/Hyprland/commit/8475a8ef992fd45be41b3217ac0f0dd71235f257) | `` core: always use goal size to send to clients ``                                           |
| [`f9c37ca4`](https://github.com/hyprwm/Hyprland/commit/f9c37ca43b14a4564d92b5788c81bf16f7bb719c) | `` windows: honor xdg_toplevel_set_fullscreen output hint (#8965) ``                          |
| [`9dc9366f`](https://github.com/hyprwm/Hyprland/commit/9dc9366fc65ca8b4f18f6554d0b147baceda01f0) | `` config: fix animations requiring all args ``                                               |
| [`85aba23c`](https://github.com/hyprwm/Hyprland/commit/85aba23cbeea2e651fa1d3f88345f9ba4d4bd4a8) | `` ci(clang-format): directly do the clang-format instead of error (#8955) ``                 |
| [`2d1ebadb`](https://github.com/hyprwm/Hyprland/commit/2d1ebadb9b65ef8d57f998031f022b29842b40e4) | `` selectors: add a tag: to for matching window tag(s) by regex (#8985) ``                    |
| [`e66eab7b`](https://github.com/hyprwm/Hyprland/commit/e66eab7b6a90514251439f661454c536afa3e5c8) | `` animationmgr: don't warp based on POINTY value (#9000) ``                                  |
| [`c9822b08`](https://github.com/hyprwm/Hyprland/commit/c9822b08f914da2997e8ef47c8bef8016e5ff313) | `` keybinds: add new window destruction dispatchers (#8962) ``                                |
| [`983bc067`](https://github.com/hyprwm/Hyprland/commit/983bc067dac2e737bc724721c79d87cd81f27501) | `` opengl: fix crash on null fb stencil op ``                                                 |
| [`b320bc2d`](https://github.com/hyprwm/Hyprland/commit/b320bc2dc6e308360936ce4396010359b74558bf) | `` core: use cpu-buffer hw cursors on nvidia by default ``                                    |
| [`ad64726f`](https://github.com/hyprwm/Hyprland/commit/ad64726f5df0fa3cabcd6af9f872d5e8e1f65dbc) | `` opengl: only allocate offMainFB on demand ``                                               |
| [`5fa25946`](https://github.com/hyprwm/Hyprland/commit/5fa2594659f9f4ad19a1afe456ee34bd1c1907b7) | `` renderer: don't access hdrMetadata optional if it has no value (#8987) ``                  |
| [`75727e7c`](https://github.com/hyprwm/Hyprland/commit/75727e7c17f31d97d518df8fdb11ec9d802ca5f3) | `` protocols: fix compilation error (#8988) ``                                                |